### PR TITLE
feat(manifests): mount docker.sock in workflow pod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ client/makeself/
 docs/_build/
 docs/docs.zip
 docs/dummy.sqlite3
-manifests/*.tmp
+manifests/*.tmp.yml
 
 # coverage reports
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ kube-delete-database:
 kube-delete-all: kube-delete kube-delete-database
 
 kube-create:
-	kubectl create -f manifests/deis-workflow-rc.yml.tmp
+	kubectl create -f manifests/deis-workflow-rc.tmp.yml
 	kubectl create -f manifests/deis-workflow-service.yml
 
 kube-create-database:
@@ -43,7 +43,7 @@ kube-create-all: kube-create-database kube-create
 
 update-manifests:
 	sed 's#\(image:\) .*#\1 $(IMAGE)#' manifests/deis-workflow-rc.yml \
-		> manifests/deis-workflow-rc.yml.tmp
+		> manifests/deis-workflow-rc.tmp.yml
 
 clean: check-docker
 	docker rmi $(IMAGE)

--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -14,10 +14,18 @@ spec:
         name: deis-workflow
     spec:
       containers:
-      - name: deis-workflow
-        image: deis/workflow:latest
-        env:
-          - name: DEBUG
-            value: "true"
-        ports:
-          - containerPort: 8000
+        - name: deis-workflow
+          image: deis/workflow:latest
+          env:
+            - name: DEBUG
+              value: "true"
+          ports:
+            - containerPort: 8000
+              name: http
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -104,9 +104,11 @@ cd /app
 mkdir -p /data/logs
 chmod 777 /data/logs
 
-# allow deis user permission to Docker
+# allow deis user group permission to Docker socket
 if addgroup -g "$(stat -c "%g" /var/run/docker.sock)" docker; then
 	addgroup deis docker
+else
+	addgroup deis "$(stat -c "%G" /var/run/docker.sock)"
 fi
 
 # run an idempotent database migration


### PR DESCRIPTION
Changes the ReplicationController manifest to mount the Docker socket into the deis-workflow pod(s). ~~I think this works but today's update to k8s v1.1.1 is giving me fits in vagrant, so this is in-progress until I've done more testing.~~ Turns out there's a problem with volumes when a manifest didn't end in ".yml" This works for me now and lets `deis pull` get as far as pushing to the (nonexistent) repository.