### PR TITLE
ref(controller): clean up scheduler code

### DIFF
--- a/rootfs/api/models.py
+++ b/rootfs/api/models.py
@@ -179,10 +179,9 @@ class App(UuidAuditedModel):
     @property
     def _scheduler(self):
         mod = importlib.import_module(settings.SCHEDULER_MODULE)
-        return mod.SchedulerClient(settings.SCHEDULER_TARGET,
+        return mod.SchedulerClient(settings.SCHEDULER_URL,
                                    settings.SCHEDULER_AUTH,
-                                   settings.SCHEDULER_OPTIONS,
-                                   settings.SSH_PRIVATE_KEY)
+                                   settings.SCHEDULER_OPTIONS)
 
     def __str__(self):
         return self.id
@@ -542,10 +541,6 @@ class App(UuidAuditedModel):
 
     def run(self, user, command):
         """Run a one-off command in an ephemeral app container."""
-        # FIXME: remove the need for SSH private keys by using
-        # a scheduler that supports one-off admin tasks natively
-        if not settings.SSH_PRIVATE_KEY:
-            raise EnvironmentError('Support for admin commands is not configured')
         if self.release_set.latest().build is None:
             raise EnvironmentError('No build associated with this release to run this command')
         # TODO: add support for interactive shell

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -245,25 +245,6 @@ class AppTest(TestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.data['count'], 1)
 
-    def test_run_without_auth(self):
-        """If the administrator has not provided SSH private key for run commands,
-        make sure a friendly error message is provided on run"""
-        settings.SSH_PRIVATE_KEY = ''
-        url = '/v1/apps'
-        body = {'id': 'autotest'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertEqual(response.status_code, 201)
-        app_id = response.data['id']  # noqa
-        # test run
-        url = '/v1/apps/{app_id}/run'.format(**locals())
-        body = {'command': 'ls -al'}
-        response = self.client.post(url, json.dumps(body), content_type='application/json',
-                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertEquals(response.status_code, 400)
-        self.assertEquals(response.data, {'detail': 'Support for admin commands '
-                                                    'is not configured'})
-
     def test_run_without_release_should_error(self):
         """
         A user should not be able to run a one-off command unless a release

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -5,7 +5,6 @@ Django settings for the Deis project.
 from __future__ import unicode_literals
 import os.path
 import random
-import semantic_version as semver
 import string
 import sys
 import tempfile
@@ -86,9 +85,6 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
-
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = None  # @UnusedVariable
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
@@ -300,12 +296,11 @@ DEIS_RESERVED_NAMES = ['deis']
 
 # default scheduler settings
 SCHEDULER_MODULE = 'scheduler.mock'
-SCHEDULER_TARGET = ''  # path to scheduler endpoint (e.g. /var/run/fleet.sock)
-SCHEDULER_AUTH = ''
-SCHEDULER_OPTIONS = {}
+SCHEDULER_URL = 'localhost'
+SCHEDULER_AUTH = None
+SCHEDULER_OPTIONS = None
 
 # security keys and auth tokens
-SSH_PRIVATE_KEY = ''  # used for SSH connections to facilitate "deis run"
 SECRET_KEY = os.environ.get('DEIS_SECRET_KEY', 'CHANGEME_sapm$s%upvsw5l_zuy_&29rkywd^78ff(qi')
 BUILDER_KEY = os.environ.get('DEIS_BUILDER_KEY', 'CHANGEME_sapm$s%upvsw5l_zuy_&29rkywd^78ff(qi')
 
@@ -373,17 +368,6 @@ except ImportError:
 if os.path.exists('/templates/confd_settings.py'):
     sys.path.append('/templates')
     from confd_settings import *  # noqa
-
-# Disable swap when mem limits are set, unless Docker is too old
-DISABLE_SWAP = '--memory-swap=-1'
-try:
-    version = 'unknown'
-    from registry.dockerclient import DockerClient
-    version = DockerClient().client.version().get('Version')
-    if not semver.validate(version) or semver.Version(version) < semver.Version('1.5.0'):
-        DISABLE_SWAP = ''
-except:
-    print("Not disabling --memory-swap for Docker version {}".format(version))
 
 # LDAP Backend Configuration
 # Should be always after the confd_settings import.

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -16,7 +16,6 @@ psycopg2==2.6.1
 python-etcd==0.3.2
 python-ldap==2.4.19
 PyYAML==3.11
-semantic_version==2.4.2
 simpleflock==0.0.2
 South==1.0.2
 static==1.1.1

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -4,11 +4,10 @@ class AbstractSchedulerClient(object):
     A generic interface to a scheduler backend.
     """
 
-    def __init__(self, target, auth, options, pkey):
+    def __init__(self, target, auth, options):
         self.target = target
         self.auth = auth
         self.options = options
-        self.pkey = pkey
 
     def create(self, name, image, command, **kwargs):
         """Create a new container."""

--- a/rootfs/scheduler/k8s.py
+++ b/rootfs/scheduler/k8s.py
@@ -100,8 +100,8 @@ MATCH = re.compile(
 
 class KubeHTTPClient(AbstractSchedulerClient):
 
-    def __init__(self, target, auth, options, pkey):
-        super(KubeHTTPClient, self).__init__(target, auth, options, pkey)
+    def __init__(self, target, auth, options):
+        super(KubeHTTPClient, self).__init__(target, auth, options)
         self.url = settings.SCHEDULER_URL
         self.registry = settings.REGISTRY_URL
         self.apiversion = "v1"


### PR DESCRIPTION
SSH_PRIVATE_KEY was something we relied on for the fleet scheduler.
We no longer require a ssh key so we can remove it. The same logic
applies for the --disable-swap option flag.