### PR TITLE
fix(confd_settings): remove old etcd dirs

### DIFF
--- a/rootfs/conf.d/confd_settings.toml
+++ b/rootfs/conf.d/confd_settings.toml
@@ -6,11 +6,6 @@ gid = 1000
 mode  = "0640"
 keys = [
   "/deis/controller",
-  "/deis/database",
-  "/deis/registry",
-  "/deis/domains",
   "/deis/platform",
-  "/deis/scheduler",
-  "/deis/logs",
 ]
 reload_cmd = "/app/bin/reload"


### PR DESCRIPTION
These should have been removed from the confd config in #10; this gets controller running again.