### PR TITLE
fix(.travis.yml): remove errant list dash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $GOPATH/src/github.com/deis/workflow/vendor
-    - $HOME/virtualenv/python2.7
+    - $HOME/venv
 services:
   - docker
   - postgresql
@@ -24,8 +24,8 @@ before_install:
   - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-4_amd64.deb"
   - sudo dpkg -i shellcheck_0.3.7-4_amd64.deb
   - sudo pip install virtualenv
-  - virtualenv $HOME/virtualenv/python2.7
-  - source $HOME/virtualenv/python2.7/bin/activate
+  - virtualenv $HOME/venv
+  - source $HOME/venv/bin/activate
   - createdb -U postgres deis
 install:
   - pip install -r rootfs/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - postgresql
 sudo: required
 addons:
-  - postgresql: "9.3"
+  postgresql: "9.3"
 before_install:
   - wget "https://github.com/Masterminds/glide/releases/download/0.7.2/glide-0.7.2-linux-amd64.tar.gz"
   - sudo tar -vxz -C /usr/local/bin --strip=1 -f glide-0.7.2-linux-amd64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 cache:
   directories:
     - $HOME/.cache/pip
-    - $GOPATH/src/github.com/deis/helm/vendor
+    - $GOPATH/src/github.com/deis/workflow/vendor
     - $HOME/virtualenv/python2.7
 services:
   - docker


### PR DESCRIPTION
Travis CI's yaml validator pointed out this error in the addons: section. Also there was a typo in the vendor cache directive, and re-using Travis' canonical location for a python virtualenv seems to have backfired, so I moved it.