### PR TITLE
Remove unused marathon and paramiko libraries

### DIFF
--- a/_scripts/ci/deploy.sh
+++ b/_scripts/ci/deploy.sh
@@ -3,7 +3,7 @@
 # Build and push Docker images to Docker Hub and quay.io.
 #
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" docker.io
 REGISTRY=docker.io IMAGE_PREFIX=deisci BUILD_TAG=v2-alpha make -C ../.. docker-build docker-push

--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -13,7 +13,6 @@ django-json-field==0.5.7
 djangorestframework==3.0.5
 docker-py==1.5.0
 gunicorn==19.3.0
-paramiko==1.15.2
 python-etcd==0.3.2
 PyYAML==3.11
 semantic_version==2.4.2

--- a/rootfs/registry/dockerclient.py
+++ b/rootfs/registry/dockerclient.py
@@ -90,10 +90,8 @@ class DockerClient(object):
 def check_blacklist(repo):
     """Check a Docker repository name for collision with deis/* components."""
     blacklisted = [  # NOTE: keep this list up to date!
-        'builder', 'cache', 'controller', 'database', 'logger', 'logspout',
-        'publisher', 'registry', 'router', 'store-admin', 'store-daemon',
-        'store-gateway', 'store-metadata', 'store-monitor', 'swarm', 'mesos-master',
-        'mesos-marathon', 'mesos-slave', 'zookeeper',
+        'builder', 'database', 'dockerbuilder', 'etcd', 'minio', 'registry', 'router',
+        'slugbuilder', 'slugrunner', 'workflow',
     ]
     if any("deis/{}".format(c) in repo for c in blacklisted):
         raise PermissionDenied("Repository name {} is not allowed".format(repo))

--- a/rootfs/registry/dockerclient.py
+++ b/rootfs/registry/dockerclient.py
@@ -90,8 +90,8 @@ class DockerClient(object):
 def check_blacklist(repo):
     """Check a Docker repository name for collision with deis/* components."""
     blacklisted = [  # NOTE: keep this list up to date!
-        'builder', 'database', 'dockerbuilder', 'etcd', 'minio', 'registry', 'router',
-        'slugbuilder', 'slugrunner', 'workflow',
+        'builder', 'controller', 'database', 'dockerbuilder', 'etcd', 'minio', 'registry',
+        'router', 'slugbuilder', 'slugrunner', 'workflow',
     ]
     if any("deis/{}".format(c) in repo for c in blacklisted):
         raise PermissionDenied("Repository name {} is not allowed".format(repo))

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -10,7 +10,6 @@ django-auth-ldap==1.2.5
 djangorestframework==3.0.5
 docker-py==1.5.0
 gunicorn==19.3.0
-marathon==0.6.15
 paramiko==1.15.2
 psycopg2==2.6.1
 python-etcd==0.3.2

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -10,7 +10,6 @@ django-auth-ldap==1.2.5
 djangorestframework==3.0.5
 docker-py==1.5.0
 gunicorn==19.3.0
-paramiko==1.15.2
 psycopg2==2.6.1
 python-etcd==0.3.2
 python-ldap==2.4.19


### PR DESCRIPTION
Marathon was used only by the mesos-marathon preview scheduler, and paramiko was used only by the fleet scheduler.