### PR TITLE
fix(settings): default to empty host environment variable

### DIFF
--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -330,7 +330,7 @@ DATABASES = {
         'NAME': os.environ.get('DEIS_DATABASE_NAME', 'deis'),
         'USER': os.environ.get('DEIS_DATABASE_USER', ''),
         'PASSWORD': os.environ.get('DEIS_DATABASE_PASSWORD', ''),
-        'HOST': os.environ.get('DEIS_DATABASE_SERVICE_HOST', '127.0.0.1'),
+        'HOST': os.environ.get('DEIS_DATABASE_SERVICE_HOST', ''),
         'PORT': os.environ.get('DEIS_DATABASE_SERVICE_PORT', 5432),
         # randomize test database name so we can run multiple unit tests simultaneously
         'TEST_NAME': "unittest-{}".format(''.join(


### PR DESCRIPTION
If you do not supply a host variable, Then psycopg2 will connect using a Unix socket in the same
manner as psql. Surprisingly, when you specify a HOST, psycopg2 will connect with TCP/IP, which
requires a password. This broke my environment with the following when running `make test-unit`:

        OperationalError: fe_sendauth: no password supplied

See: http://stackoverflow.com/a/23871618