### PR TITLE
fix(make): use DEIS_REGISTRY as an env var for consisteny

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-
-REGISTRY ?= $(DEV_REGISTRY)
+# If DEIS_REGISTRY is not set, try to populate it from legacy DEV_REGISTRY
+DEIS_REGISTRY ?= $(DEV_REGISTRY)
 IMAGE_PREFIX ?= deis
 COMPONENT ?= workflow
 BUILD_TAG ?= git-$(shell git rev-parse --short HEAD)
-IMAGE = $(REGISTRY)/$(IMAGE_PREFIX)/$(COMPONENT):$(BUILD_TAG)
+IMAGE = $(DEIS_REGISTRY)/$(IMAGE_PREFIX)/$(COMPONENT):$(BUILD_TAG)
 SHELL_SCRIPTS = $(wildcard rootfs/bin/*) $(shell find "rootfs" -name '*.sh') $(shell find "_scripts/ci" -name '*.sh')
 
 check-docker:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ kubectl exec alpine -- curl -sS 10.247.187.217:4100/version
 {"etcdserver":"2.2.1","etcdcluster":"2.2.0"}
 ```
 
-Next build the deis/workflow image and push it to a Docker registry. The `$DEV_REGISTRY` environment variable must point to a registry accessible to your Kubernetes cluster. You may need to configure the Docker engines on your Kubernetes nodes to allow `--insecure-registry 192.168.0.0/16` (or the appropriate address range).
+Next build the deis/workflow image and push it to a Docker registry. The `$DEIS_REGISTRY` environment variable must point to a registry accessible to your Kubernetes cluster. You may need to configure the Docker engines on your Kubernetes nodes to allow `--insecure-registry 192.168.0.0/16` (or the appropriate address range).
 
 ```console
 $ make docker-build docker-push

--- a/_scripts/ci/deploy.sh
+++ b/_scripts/ci/deploy.sh
@@ -6,6 +6,6 @@
 cd "$(dirname "$0")" || exit 1
 
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" docker.io
-REGISTRY=docker.io IMAGE_PREFIX=deisci BUILD_TAG=v2-alpha make -C ../.. docker-build docker-push
+DEIS_REGISTRY=docker.io IMAGE_PREFIX=deisci BUILD_TAG=v2-alpha make -C ../.. docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
-REGISTRY=quay.io IMAGE_PREFIX=deisci BUILD_TAG=v2-alpha make -C ../.. docker-build docker-push
+DEIS_REGISTRY=quay.io IMAGE_PREFIX=deisci BUILD_TAG=v2-alpha make -C ../.. docker-build docker-push

--- a/docs/contributing/hacking.rst
+++ b/docs/contributing/hacking.rst
@@ -299,20 +299,20 @@ With a dev cluster now running, we are ready to set up a local Docker registry.
 Configure a Docker Registry
 ---------------------------
 
-The development workflow requires Docker Registry set at the ``DEV_REGISTRY``
+The development workflow requires Docker Registry set at the ``DEIS_REGISTRY``
 environment variable.  If you're developing locally you can use the ``dev-registry``
 target to spin up a quick, disposable registry inside a Docker container.
 The target ``dev-registry`` prints the registry's address and port when using ``docker-machine``;
-otherwise, use your host's IP address as returned by ``ifconfig`` with port 5000 for ``DEV_REGISTRY``.
+otherwise, use your host's IP address as returned by ``ifconfig`` with port 5000 for ``DEIS_REGISTRY``.
 
 .. code-block:: console
 
     $ make dev-registry
 
     To configure the registry for local Deis development:
-        export DEV_REGISTRY=192.168.59.103:5000
+        export DEIS_REGISTRY=192.168.59.103:5000
 
-It is important that you export the ``DEV_REGISTRY`` variable as instructed.
+It is important that you export the ``DEIS_REGISTRY`` variable as instructed.
 
 If you are developing elsewhere, you must set up a registry yourself.
 Make sure it meets the following requirements:

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -54,7 +54,7 @@ continuous deployment, start one locally.
     registry
 
     To use local registry for Deis development:
-        export DEV_REGISTRY=192.168.59.103:5000
+        export DEIS_REGISTRY=192.168.59.103:5000
 
 .. important::
 


### PR DESCRIPTION
`deis/router` is doing it and seems more consistent with our naming policies