### PR TITLE
chore(build): remove git from image, no longer needed

### DIFF
--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -11,10 +11,8 @@ if [[ -z $DOCKER_BUILD ]]; then
 fi
 
 # install required system packages
-# HACK: install git so we can install bacongobbler's fork of django-fsm
 apk add --update-cache \
   build-base \
-  git \
   libffi-dev \
   libpq \
   openldap \
@@ -41,7 +39,6 @@ pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 # cleanup.
 apk del --purge \
   build-base \
-  git \
   libffi-dev \
   openldap-dev \
   postgresql-dev \


### PR DESCRIPTION
django-fsm used to need git installed to pull in a fork but the need for it was dropped https://github.com/deis/deis/commit/a6515c85e569859a2d6ce6b63e2e332f7b711e86