### PR TITLE
fix(build): add curl again (came via git before) to install pip

### DIFF
--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -13,6 +13,7 @@ fi
 # install required system packages
 apk add --update-cache \
   build-base \
+  curl \
   libffi-dev \
   libpq \
   openldap \
@@ -39,6 +40,7 @@ pip install --disable-pip-version-check --no-cache-dir -r /app/requirements.txt
 # cleanup.
 apk del --purge \
   build-base \
+  curl \
   libffi-dev \
   openldap-dev \
   postgresql-dev \


### PR DESCRIPTION
`curl` is needed for the pip installation and came in via `git` before. 

https://pkgs.alpinelinux.org/package/main/x86_64/git depends on `curl` 