### PR TITLE
feat(*): change format of one off commands response and bump api to v2

### DIFF
--- a/client/controller/api/apps.go
+++ b/client/controller/api/apps.go
@@ -10,22 +10,22 @@ type App struct {
 	UUID    string `json:"uuid"`
 }
 
-// AppCreateRequest is the definition of POST /v1/apps/.
+// AppCreateRequest is the definition of POST /v2/apps/.
 type AppCreateRequest struct {
 	ID string `json:"id,omitempty"`
 }
 
-// AppUpdateRequest is the definition of POST /v1/apps/<app id>/.
+// AppUpdateRequest is the definition of POST /v2/apps/<app id>/.
 type AppUpdateRequest struct {
 	Owner string `json:"owner,omitempty"`
 }
 
-// AppRunRequest is the definition of POST /v1/apps/<app id>/run.
+// AppRunRequest is the definition of POST /v2/apps/<app id>/run.
 type AppRunRequest struct {
 	Command string `json:"command"`
 }
 
-// AppRunResponse is the definition of /v1/apps/<app id>/run.
+// AppRunResponse is the definition of /v2/apps/<app id>/run.
 type AppRunResponse struct {
 	Output     string `json:"output"`
 	ReturnCode int    `json:"rc"`

--- a/client/controller/api/auth.go
+++ b/client/controller/api/auth.go
@@ -1,6 +1,6 @@
 package api
 
-// AuthRegisterRequest is the definition of POST /v1/auth/register/.
+// AuthRegisterRequest is the definition of POST /v2/auth/register/.
 type AuthRegisterRequest struct {
 	Username  string `json:"username"`
 	Password  string `json:"password"`
@@ -9,34 +9,34 @@ type AuthRegisterRequest struct {
 	LastName  string `json:"last_name,omitempty"`
 }
 
-// AuthLoginRequest is the definition of POST /v1/auth/login/.
+// AuthLoginRequest is the definition of POST /v2/auth/login/.
 type AuthLoginRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
 
-// AuthLoginResponse is the definition of /v1/auth/login/.
+// AuthLoginResponse is the definition of /v2/auth/login/.
 type AuthLoginResponse tokenResponse
 
-// AuthPasswdRequest is the definition of POST /v1/auth/passwd/.
+// AuthPasswdRequest is the definition of POST /v2/auth/passwd/.
 type AuthPasswdRequest struct {
 	Username    string `json:"username,omitempty"`
 	Password    string `json:"password,omitempty"`
 	NewPassword string `json:"new_password"`
 }
 
-// AuthRegenerateRequest is the definition of POST /v1/auth/tokens/.
+// AuthRegenerateRequest is the definition of POST /v2/auth/tokens/.
 type AuthRegenerateRequest struct {
 	Name string `json:"username,omitempty"`
 	All  bool   `json:"all,omitempty"`
 }
 
-// AuthCancelRequest is the definition of POST /v1/auth/cancel/.
+// AuthCancelRequest is the definition of POST /v2/auth/cancel/.
 type AuthCancelRequest struct {
 	Username string `json:"username"`
 }
 
-// AuthRegenerateResponse is the definition of /v1/auth/tokens/.
+// AuthRegenerateResponse is the definition of /v2/auth/tokens/.
 type AuthRegenerateResponse tokenResponse
 
 // A generic defenition of a token response.

--- a/client/controller/api/builds.go
+++ b/client/controller/api/builds.go
@@ -13,7 +13,7 @@ type Build struct {
 	UUID       string            `json:"uuid"`
 }
 
-// CreateBuildRequest is the structure of POST /v1/apps/<app id>/builds/.
+// CreateBuildRequest is the structure of POST /v2/apps/<app id>/builds/.
 type CreateBuildRequest struct {
 	Image    string            `json:"image"`
 	Procfile map[string]string `json:"procfile,omitempty"`

--- a/client/controller/api/certs.go
+++ b/client/controller/api/certs.go
@@ -12,7 +12,7 @@ type Cert struct {
 	ID      int    `json:"id,omitempty"`
 }
 
-// CertCreateRequest is the definition of POST /v1/certs/.
+// CertCreateRequest is the definition of POST /v2/certs/.
 type CertCreateRequest struct {
 	Certificate string `json:"certificate"`
 	Key         string `json:"key"`

--- a/client/controller/api/config.go
+++ b/client/controller/api/config.go
@@ -1,11 +1,11 @@
 package api
 
-// ConfigSet is the definition of POST /v1/apps/<app id>/config/.
+// ConfigSet is the definition of POST /v2/apps/<app id>/config/.
 type ConfigSet struct {
 	Values map[string]string `json:"values"`
 }
 
-// ConfigUnset is the definition of POST /v1/apps/<app id>/config/.
+// ConfigUnset is the definition of POST /v2/apps/<app id>/config/.
 type ConfigUnset struct {
 	Values map[string]interface{} `json:"values"`
 }

--- a/client/controller/api/domains.go
+++ b/client/controller/api/domains.go
@@ -9,7 +9,7 @@ type Domain struct {
 	Updated string `json:"updated"`
 }
 
-// DomainCreateRequest is the structure of POST /v1/app/<app id>/domains/.
+// DomainCreateRequest is the structure of POST /v2/app/<app id>/domains/.
 type DomainCreateRequest struct {
 	Domain string `json:"domain"`
 }

--- a/client/controller/api/keys.go
+++ b/client/controller/api/keys.go
@@ -10,7 +10,7 @@ type Key struct {
 	UUID    string `json:"uuid"`
 }
 
-// KeyCreateRequest is the definition of POST /v1/keys/.
+// KeyCreateRequest is the definition of POST /v2/keys/.
 type KeyCreateRequest struct {
 	ID     string `json:"id"`
 	Public string `json:"public"`

--- a/client/controller/api/perms.go
+++ b/client/controller/api/perms.go
@@ -1,6 +1,6 @@
 package api
 
-// PermsAppResponse is the definition of GET /v1/apps/<app id>/perms/.
+// PermsAppResponse is the definition of GET /v2/apps/<app id>/perms/.
 type PermsAppResponse struct {
 	Users []string `json:"users"`
 }

--- a/client/controller/api/releases.go
+++ b/client/controller/api/releases.go
@@ -13,7 +13,7 @@ type Release struct {
 	Version int    `json:"version"`
 }
 
-// ReleaseRollback is the defenition of POST /v1/apps/<app id>/releases/.
+// ReleaseRollback is the defenition of POST /v2/apps/<app id>/releases/.
 type ReleaseRollback struct {
 	Version int `json:"version"`
 }

--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -159,7 +159,7 @@ Make sure that the Controller URI is correct and the server is running.`
 
 	baseURL := controllerURL.String()
 
-	controllerURL.Path = "/v1/"
+	controllerURL.Path = "/v2/"
 
 	req, err := http.NewRequest("GET", controllerURL.String(), bytes.NewBuffer(nil))
 	addUserAgent(&req.Header)

--- a/client/controller/client/http_test.go
+++ b/client/controller/client/http_test.go
@@ -41,7 +41,7 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/" {
+	if req.URL.Path == "/v2/" {
 		res.WriteHeader(http.StatusUnauthorized)
 		res.Write(nil)
 		return

--- a/client/controller/models/apps/apps.go
+++ b/client/controller/models/apps/apps.go
@@ -12,7 +12,7 @@ import (
 
 // List lists apps on a Deis controller.
 func List(c *client.Client, results int) ([]api.App, int, error) {
-	body, count, err := c.LimitedRequest("/v1/apps/", results)
+	body, count, err := c.LimitedRequest("/v2/apps/", results)
 
 	if err != nil {
 		return []api.App{}, -1, err
@@ -40,7 +40,7 @@ func New(c *client.Client, id string) (api.App, error) {
 		}
 	}
 
-	resBody, err := c.BasicRequest("POST", "/v1/apps/", body)
+	resBody, err := c.BasicRequest("POST", "/v2/apps/", body)
 
 	if err != nil {
 		return api.App{}, err
@@ -56,7 +56,7 @@ func New(c *client.Client, id string) (api.App, error) {
 
 // Get app details from a Deis controller.
 func Get(c *client.Client, appID string) (api.App, error) {
-	u := fmt.Sprintf("/v1/apps/%s/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/", appID)
 
 	body, err := c.BasicRequest("GET", u, nil)
 
@@ -75,7 +75,7 @@ func Get(c *client.Client, appID string) (api.App, error) {
 
 // Logs retrieves logs from an app.
 func Logs(c *client.Client, appID string, lines int) (string, error) {
-	u := fmt.Sprintf("/v1/apps/%s/logs", appID)
+	u := fmt.Sprintf("/v2/apps/%s/logs", appID)
 
 	if lines > 0 {
 		u += "?log_lines=" + strconv.Itoa(lines)
@@ -99,7 +99,7 @@ func Run(c *client.Client, appID string, command string) (api.AppRunResponse, er
 		return api.AppRunResponse{}, err
 	}
 
-	u := fmt.Sprintf("/v1/apps/%s/run", appID)
+	u := fmt.Sprintf("/v2/apps/%s/run", appID)
 
 	resBody, err := c.BasicRequest("POST", u, body)
 
@@ -107,18 +107,18 @@ func Run(c *client.Client, appID string, command string) (api.AppRunResponse, er
 		return api.AppRunResponse{}, err
 	}
 
-	out := make([]interface{}, 2)
+	res := api.AppRunResponse{}
 
-	if err = json.Unmarshal([]byte(resBody), &out); err != nil {
+	if err = json.Unmarshal([]byte(resBody), &res); err != nil {
 		return api.AppRunResponse{}, err
 	}
 
-	return api.AppRunResponse{Output: out[1].(string), ReturnCode: int(out[0].(float64))}, nil
+	return res, nil
 }
 
 // Delete an app.
 func Delete(c *client.Client, appID string) error {
-	u := fmt.Sprintf("/v1/apps/%s/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/", appID)
 
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err
@@ -126,7 +126,7 @@ func Delete(c *client.Client, appID string) error {
 
 // Transfer an app to another user.
 func Transfer(c *client.Client, appID string, username string) error {
-	u := fmt.Sprintf("/v1/apps/%s/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/", appID)
 
 	req := api.AppUpdateRequest{Owner: username}
 	body, err := json.Marshal(req)

--- a/client/controller/models/apps/apps_test.go
+++ b/client/controller/models/apps/apps_test.go
@@ -55,7 +55,7 @@ type fakeHTTPServer struct {
 func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/apps/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -82,33 +82,33 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/" && req.Method == "GET" {
 		res.Write([]byte(appsFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/" && req.Method == "GET" {
 		res.Write([]byte(appFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/apps/example-go/" && req.Method == "DELETE" {
 		res.WriteHeader(http.StatusNoContent)
 		res.Write(nil)
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/logs" && req.URL.RawQuery == "" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/logs" && req.URL.RawQuery == "" && req.Method == "GET" {
 		res.Write([]byte("test\nfoo\nbar\n"))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/logs" && req.URL.RawQuery == "log_lines=1" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/logs" && req.URL.RawQuery == "log_lines=1" && req.Method == "GET" {
 		res.Write([]byte("test\n"))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/run" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/run" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -124,11 +124,11 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		res.Write([]byte(`[0,"hi\n"]`))
+		res.Write([]byte(`{"rc":0,"output":"hi\n"}`))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {

--- a/client/controller/models/auth/auth.go
+++ b/client/controller/models/auth/auth.go
@@ -16,7 +16,7 @@ func Register(c *client.Client, username, password, email string) error {
 		return err
 	}
 
-	_, err = c.BasicRequest("POST", "/v1/auth/register/", body)
+	_, err = c.BasicRequest("POST", "/v2/auth/register/", body)
 	return err
 }
 
@@ -29,7 +29,7 @@ func Login(c *client.Client, username, password string) (string, error) {
 		return "", err
 	}
 
-	body, err := c.BasicRequest("POST", "/v1/auth/login/", reqBody)
+	body, err := c.BasicRequest("POST", "/v2/auth/login/", reqBody)
 
 	if err != nil {
 		return "", err
@@ -57,7 +57,7 @@ func Delete(c *client.Client, username string) error {
 		}
 	}
 
-	_, err = c.BasicRequest("DELETE", "/v1/auth/cancel/", body)
+	_, err = c.BasicRequest("DELETE", "/v2/auth/cancel/", body)
 	return err
 }
 
@@ -76,7 +76,7 @@ func Regenerate(c *client.Client, username string, all bool) (string, error) {
 		return "", err
 	}
 
-	body, err := c.BasicRequest("POST", "/v1/auth/tokens/", reqBody)
+	body, err := c.BasicRequest("POST", "/v2/auth/tokens/", reqBody)
 
 	if err != nil {
 		return "", err
@@ -108,6 +108,6 @@ func Passwd(c *client.Client, username, password, newPassword string) error {
 		return err
 	}
 
-	_, err = c.BasicRequest("POST", "/v1/auth/passwd/", body)
+	_, err = c.BasicRequest("POST", "/v2/auth/passwd/", body)
 	return err
 }

--- a/client/controller/models/auth/auth_test.go
+++ b/client/controller/models/auth/auth_test.go
@@ -30,7 +30,7 @@ type fakeHTTPServer struct {
 func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/auth/register/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/auth/register/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -51,7 +51,7 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/auth/login/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/auth/login/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -72,7 +72,7 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/auth/passwd/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/auth/passwd/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -93,7 +93,7 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/auth/tokens/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/auth/tokens/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -122,7 +122,7 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/auth/cancel/" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/auth/cancel/" && req.Method == "DELETE" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {

--- a/client/controller/models/builds/builds.go
+++ b/client/controller/models/builds/builds.go
@@ -10,7 +10,7 @@ import (
 
 // List lists an app's builds.
 func List(c *client.Client, appID string, results int) ([]api.Build, int, error) {
-	u := fmt.Sprintf("/v1/apps/%s/builds/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/builds/", appID)
 	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
@@ -29,7 +29,7 @@ func List(c *client.Client, appID string, results int) ([]api.Build, int, error)
 func New(c *client.Client, appID string, image string,
 	procfile map[string]string) (api.Build, error) {
 
-	u := fmt.Sprintf("/v1/apps/%s/builds/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/builds/", appID)
 
 	req := api.CreateBuildRequest{Image: image, Procfile: procfile}
 

--- a/client/controller/models/builds/builds_test.go
+++ b/client/controller/models/builds/builds_test.go
@@ -58,12 +58,12 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/apps/example-go/builds/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/builds/" && req.Method == "GET" {
 		res.Write([]byte(buildsFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/builds/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/builds/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {

--- a/client/controller/models/certs/certs.go
+++ b/client/controller/models/certs/certs.go
@@ -10,7 +10,7 @@ import (
 
 // List certs registered with the controller.
 func List(c *client.Client, results int) ([]api.Cert, int, error) {
-	body, count, err := c.LimitedRequest("/v1/certs/", results)
+	body, count, err := c.LimitedRequest("/v2/certs/", results)
 
 	if err != nil {
 		return []api.Cert{}, -1, err
@@ -33,7 +33,7 @@ func New(c *client.Client, cert string, key string, commonName string) (api.Cert
 		return api.Cert{}, err
 	}
 
-	resBody, err := c.BasicRequest("POST", "/v1/certs/", reqBody)
+	resBody, err := c.BasicRequest("POST", "/v2/certs/", reqBody)
 
 	if err != nil {
 		return api.Cert{}, err
@@ -49,7 +49,7 @@ func New(c *client.Client, cert string, key string, commonName string) (api.Cert
 
 // Delete removes a cert.
 func Delete(c *client.Client, commonName string) error {
-	u := fmt.Sprintf("/v1/certs/%s", commonName)
+	u := fmt.Sprintf("/v2/certs/%s", commonName)
 
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err

--- a/client/controller/models/certs/certs_test.go
+++ b/client/controller/models/certs/certs_test.go
@@ -44,12 +44,12 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/certs/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/certs/" && req.Method == "GET" {
 		res.Write([]byte(certsFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/certs/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/certs/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -69,7 +69,7 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/certs/test.example.com" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/certs/test.example.com" && req.Method == "DELETE" {
 		res.WriteHeader(http.StatusNoContent)
 		res.Write(nil)
 		return

--- a/client/controller/models/config/config.go
+++ b/client/controller/models/config/config.go
@@ -10,7 +10,7 @@ import (
 
 // List lists an app's config.
 func List(c *client.Client, app string) (api.Config, error) {
-	u := fmt.Sprintf("/v1/apps/%s/config/", app)
+	u := fmt.Sprintf("/v2/apps/%s/config/", app)
 
 	body, err := c.BasicRequest("GET", u, nil)
 
@@ -34,7 +34,7 @@ func Set(c *client.Client, app string, config api.Config) (api.Config, error) {
 		return api.Config{}, err
 	}
 
-	u := fmt.Sprintf("/v1/apps/%s/config/", app)
+	u := fmt.Sprintf("/v2/apps/%s/config/", app)
 
 	resBody, err := c.BasicRequest("POST", u, body)
 

--- a/client/controller/models/config/config_test.go
+++ b/client/controller/models/config/config_test.go
@@ -59,7 +59,7 @@ type fakeHTTPServer struct{}
 func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/apps/example-go/config/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/config/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -80,7 +80,7 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/unset-test/config/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/unset-test/config/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -101,7 +101,7 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/config/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/config/" && req.Method == "GET" {
 		res.Write([]byte(configFixture))
 		return
 	}

--- a/client/controller/models/domains/domains.go
+++ b/client/controller/models/domains/domains.go
@@ -10,7 +10,7 @@ import (
 
 // List domains registered with an app.
 func List(c *client.Client, appID string, results int) ([]api.Domain, int, error) {
-	u := fmt.Sprintf("/v1/apps/%s/domains/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/domains/", appID)
 	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
@@ -27,7 +27,7 @@ func List(c *client.Client, appID string, results int) ([]api.Domain, int, error
 
 // New adds a domain to an app.
 func New(c *client.Client, appID string, domain string) (api.Domain, error) {
-	u := fmt.Sprintf("/v1/apps/%s/domains/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/domains/", appID)
 
 	req := api.DomainCreateRequest{Domain: domain}
 
@@ -53,7 +53,7 @@ func New(c *client.Client, appID string, domain string) (api.Domain, error) {
 
 // Delete removes a domain from an app.
 func Delete(c *client.Client, appID string, domain string) error {
-	u := fmt.Sprintf("/v1/apps/%s/domains/%s", appID, domain)
+	u := fmt.Sprintf("/v2/apps/%s/domains/%s", appID, domain)
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err
 }

--- a/client/controller/models/domains/domains_test.go
+++ b/client/controller/models/domains/domains_test.go
@@ -46,12 +46,12 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/apps/example-go/domains/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/domains/" && req.Method == "GET" {
 		res.Write([]byte(domainsFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/domains/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/domains/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -72,7 +72,7 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/domains/test.com" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/apps/example-go/domains/test.com" && req.Method == "DELETE" {
 		res.WriteHeader(http.StatusNoContent)
 		res.Write([]byte(domainsFixture))
 		return

--- a/client/controller/models/keys/keys.go
+++ b/client/controller/models/keys/keys.go
@@ -10,7 +10,7 @@ import (
 
 // List keys on a controller.
 func List(c *client.Client, results int) ([]api.Key, int, error) {
-	body, count, err := c.LimitedRequest("/v1/keys/", results)
+	body, count, err := c.LimitedRequest("/v2/keys/", results)
 
 	if err != nil {
 		return []api.Key{}, -1, err
@@ -29,7 +29,7 @@ func New(c *client.Client, id string, pubKey string) (api.Key, error) {
 	req := api.KeyCreateRequest{ID: id, Public: pubKey}
 	body, err := json.Marshal(req)
 
-	resBody, err := c.BasicRequest("POST", "/v1/keys/", body)
+	resBody, err := c.BasicRequest("POST", "/v2/keys/", body)
 
 	if err != nil {
 		return api.Key{}, err
@@ -45,7 +45,7 @@ func New(c *client.Client, id string, pubKey string) (api.Key, error) {
 
 // Delete a key.
 func Delete(c *client.Client, keyID string) error {
-	u := fmt.Sprintf("/v1/keys/%s", keyID)
+	u := fmt.Sprintf("/v2/keys/%s", keyID)
 
 	_, err := c.BasicRequest("DELETE", u, nil)
 	return err

--- a/client/controller/models/keys/keys_test.go
+++ b/client/controller/models/keys/keys_test.go
@@ -48,12 +48,12 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/keys/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/keys/" && req.Method == "GET" {
 		res.Write([]byte(keysListFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/keys/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/keys/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -74,7 +74,7 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/keys/test@example.com" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/keys/test@example.com" && req.Method == "DELETE" {
 		res.WriteHeader(http.StatusNoContent)
 		res.Write(nil)
 		return

--- a/client/controller/models/perms/perms.go
+++ b/client/controller/models/perms/perms.go
@@ -10,7 +10,7 @@ import (
 
 // List users that can access an app.
 func List(c *client.Client, appID string) ([]string, error) {
-	body, err := c.BasicRequest("GET", fmt.Sprintf("/v1/apps/%s/perms/", appID), nil)
+	body, err := c.BasicRequest("GET", fmt.Sprintf("/v2/apps/%s/perms/", appID), nil)
 
 	if err != nil {
 		return []string{}, err
@@ -26,7 +26,7 @@ func List(c *client.Client, appID string) ([]string, error) {
 
 // ListAdmins lists administrators.
 func ListAdmins(c *client.Client, results int) ([]string, int, error) {
-	body, count, err := c.LimitedRequest("/v1/admin/perms/", results)
+	body, count, err := c.LimitedRequest("/v2/admin/perms/", results)
 
 	if err != nil {
 		return []string{}, -1, err
@@ -48,12 +48,12 @@ func ListAdmins(c *client.Client, results int) ([]string, int, error) {
 
 // New adds a user to an app.
 func New(c *client.Client, appID string, username string) error {
-	return doNew(c, fmt.Sprintf("/v1/apps/%s/perms/", appID), username)
+	return doNew(c, fmt.Sprintf("/v2/apps/%s/perms/", appID), username)
 }
 
 // NewAdmin makes a user an administrator.
 func NewAdmin(c *client.Client, username string) error {
-	return doNew(c, "/v1/admin/perms/", username)
+	return doNew(c, "/v2/admin/perms/", username)
 }
 
 func doNew(c *client.Client, u string, username string) error {
@@ -76,12 +76,12 @@ func doNew(c *client.Client, u string, username string) error {
 
 // Delete removes a user from an app.
 func Delete(c *client.Client, appID string, username string) error {
-	return doDelete(c, fmt.Sprintf("/v1/apps/%s/perms/%s", appID, username))
+	return doDelete(c, fmt.Sprintf("/v2/apps/%s/perms/%s", appID, username))
 }
 
 // DeleteAdmin removes administrative privilages from a user.
 func DeleteAdmin(c *client.Client, username string) error {
-	return doDelete(c, fmt.Sprintf("/v1/admin/perms/%s", username))
+	return doDelete(c, fmt.Sprintf("/v2/admin/perms/%s", username))
 }
 
 func doDelete(c *client.Client, u string) error {

--- a/client/controller/models/perms/perms_test.go
+++ b/client/controller/models/perms/perms_test.go
@@ -46,12 +46,12 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/admin/perms/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/admin/perms/" && req.Method == "GET" {
 		res.Write([]byte(adminFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/admin/perms/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/admin/perms/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -72,24 +72,24 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/admin/perms/test" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/admin/perms/test" && req.Method == "DELETE" {
 		res.WriteHeader(http.StatusNoContent)
 		res.Write(nil)
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/perms/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/perms/" && req.Method == "GET" {
 		res.Write([]byte(appPermsFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/perms/foo" && req.Method == "DELETE" {
+	if req.URL.Path == "/v2/apps/example-go/perms/foo" && req.Method == "DELETE" {
 		res.WriteHeader(http.StatusNoContent)
 		res.Write(nil)
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/perms/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/perms/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {

--- a/client/controller/models/ps/ps.go
+++ b/client/controller/models/ps/ps.go
@@ -11,7 +11,7 @@ import (
 
 // List an app's processes.
 func List(c *client.Client, appID string, results int) ([]api.Process, int, error) {
-	u := fmt.Sprintf("/v1/apps/%s/containers/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/containers/", appID)
 	body, count, err := c.LimitedRequest(u, results)
 
 	if err != nil {
@@ -28,7 +28,7 @@ func List(c *client.Client, appID string, results int) ([]api.Process, int, erro
 
 // Scale an app's processes.
 func Scale(c *client.Client, appID string, targets map[string]int) error {
-	u := fmt.Sprintf("/v1/apps/%s/scale/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/scale/", appID)
 
 	body, err := json.Marshal(targets)
 
@@ -42,7 +42,7 @@ func Scale(c *client.Client, appID string, targets map[string]int) error {
 
 // Restart an app's processes.
 func Restart(c *client.Client, appID string, procType string, num int) ([]api.Process, error) {
-	u := fmt.Sprintf("/v1/apps/%s/containers/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/containers/", appID)
 
 	if procType == "" {
 		u += "restart/"

--- a/client/controller/models/ps/ps_test.go
+++ b/client/controller/models/ps/ps_test.go
@@ -86,27 +86,27 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/apps/example-go/containers/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/containers/" && req.Method == "GET" {
 		res.Write([]byte(processesFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/containers/restart/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/containers/restart/" && req.Method == "POST" {
 		res.Write([]byte(restartAllFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/containers/worker/restart/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/containers/worker/restart/" && req.Method == "POST" {
 		res.Write([]byte(restartWorkerFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/containers/web/2/restart/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/containers/web/2/restart/" && req.Method == "POST" {
 		res.Write([]byte(restartWebTwoFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/scale/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/scale/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {

--- a/client/controller/models/releases/releases.go
+++ b/client/controller/models/releases/releases.go
@@ -10,7 +10,7 @@ import (
 
 // List lists an app's releases.
 func List(c *client.Client, appID string, results int) ([]api.Release, int, error) {
-	u := fmt.Sprintf("/v1/apps/%s/releases/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/releases/", appID)
 
 	body, count, err := c.LimitedRequest(u, results)
 
@@ -28,7 +28,7 @@ func List(c *client.Client, appID string, results int) ([]api.Release, int, erro
 
 // Get a release of an app.
 func Get(c *client.Client, appID string, version int) (api.Release, error) {
-	u := fmt.Sprintf("/v1/apps/%s/releases/v%d/", appID, version)
+	u := fmt.Sprintf("/v2/apps/%s/releases/v%d/", appID, version)
 
 	body, err := c.BasicRequest("GET", u, nil)
 
@@ -46,7 +46,7 @@ func Get(c *client.Client, appID string, version int) (api.Release, error) {
 
 // Rollback rolls back an app to a previous release.
 func Rollback(c *client.Client, appID string, version int) (int, error) {
-	u := fmt.Sprintf("/v1/apps/%s/releases/rollback/", appID)
+	u := fmt.Sprintf("/v2/apps/%s/releases/rollback/", appID)
 
 	req := api.ReleaseRollback{Version: version}
 

--- a/client/controller/models/releases/releases_test.go
+++ b/client/controller/models/releases/releases_test.go
@@ -63,17 +63,17 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/apps/example-go/releases/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/releases/" && req.Method == "GET" {
 		res.Write([]byte(releasesFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/releases/v1/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/apps/example-go/releases/v1/" && req.Method == "GET" {
 		res.Write([]byte(releaseFixture))
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/example-go/releases/rollback/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/example-go/releases/rollback/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {
@@ -94,7 +94,7 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/v1/apps/rollbacker/releases/rollback/" && req.Method == "POST" {
+	if req.URL.Path == "/v2/apps/rollbacker/releases/rollback/" && req.Method == "POST" {
 		body, err := ioutil.ReadAll(req.Body)
 
 		if err != nil {

--- a/client/controller/models/users/users.go
+++ b/client/controller/models/users/users.go
@@ -9,7 +9,7 @@ import (
 
 // List users registered with the controller.
 func List(c *client.Client, results int) ([]api.User, int, error) {
-	body, count, err := c.LimitedRequest("/v1/users/", results)
+	body, count, err := c.LimitedRequest("/v2/users/", results)
 
 	if err != nil {
 		return []api.User{}, -1, err

--- a/client/controller/models/users/users_test.go
+++ b/client/controller/models/users/users_test.go
@@ -41,7 +41,7 @@ type fakeHTTPServer struct{}
 func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("DEIS_API_VERSION", version.APIVersion)
 
-	if req.URL.Path == "/v1/users/" && req.Method == "GET" {
+	if req.URL.Path == "/v2/users/" && req.Method == "GET" {
 		res.Write([]byte(usersFixture))
 		return
 	}

--- a/client/version/version.go
+++ b/client/version/version.go
@@ -4,4 +4,4 @@ package version
 const Version = "1.13.0-dev"
 
 // API identifies the latest Deis api verison
-const APIVersion = "1.7"
+const APIVersion = "2.0"

--- a/docs/src/reference-guide/controller-api/v2.0
+++ b/docs/src/reference-guide/controller-api/v2.0
@@ -1,0 +1,1370 @@
+# Controller API v2.0
+
+This is the v2.0 REST API for the Controller.
+
+## What's New
+
+**New!** format of `POST /v2/apps/<app id>/run` has changed.
+
+## Authentication
+
+### Register a New User
+
+Example Request:
+
+```
+POST /v1/auth/register/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+
+{
+    "username": "test",
+    "password": "opensesame",
+    "email": "test@example.com"
+}
+```
+
+Optional Parameters:
+
+```
+{
+    "first_name": "test",
+    "last_name": "testerson"
+}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "id": 1,
+    "last_login": "2014-10-19T22:01:00.601Z",
+    "is_superuser": true,
+    "username": "test",
+    "first_name": "test",
+    "last_name": "testerson",
+    "email": "test@example.com",
+    "is_staff": true,
+    "is_active": true,
+    "date_joined": "2014-10-19T22:01:00.601Z",
+    "groups": [],
+    "user_permissions": []
+}
+```
+
+### Log in
+
+Example Request:
+
+```
+POST /v1/auth/login/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+
+{"username": "test", "password": "opensesame"}
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{"token": "abc123"}
+```
+
+### Cancel Account
+
+Example Request:
+
+```
+DELETE /v1/auth/cancel/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+### Regenerate Token
+
+> **note**
+>
+> This command could require administrative privileges
+
+Example Request:
+
+```
+POST /v1/auth/tokens/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Optional Parameters:
+
+```
+{
+    "username" : "test"
+    "all" : "true"
+}
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{"token": "abc123"}
+```
+
+### Change Password
+
+Example Request:
+
+```
+POST /v1/auth/passwd/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+
+{
+    "password": "foo",
+    "new_password": "bar"
+}
+```
+
+Optional parameters:
+
+```
+{"username": "testuser"}
+```
+
+> **note**
+>
+> Using the `username` parameter requires administrative privileges and makes the `password` parameter optional.
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+## Applications
+
+### List all Applications
+
+Example Request:
+
+```
+GET /v1/apps HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "created": "2014-01-01T00:00:00UTC",
+            "id": "example-go",
+            "owner": "test",
+            "structure": {},
+            "updated": "2014-01-01T00:00:00UTC",
+            "url": "example-go.example.com",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+        }
+    ]
+}
+```
+
+### Create an Application
+
+Example Request:
+
+```
+POST /v1/apps/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+```
+
+Optional parameters:
+
+```
+{"id": "example-go"}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "created": "2014-01-01T00:00:00UTC",
+    "id": "example-go",
+    "owner": "test",
+    "structure": {},
+    "updated": "2014-01-01T00:00:00UTC",
+    "url": "example-go.example.com",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+### Destroy an Application
+
+Example Request:
+
+```
+DELETE /v1/apps/example-go/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+### List Application Details
+
+Example Request:
+
+```
+GET /v1/apps/example-go/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "created": "2014-01-01T00:00:00UTC",
+    "id": "example-go",
+    "owner": "test",
+    "structure": {},
+    "updated": "2014-01-01T00:00:00UTC",
+    "url": "example-go.example.com",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+### Update Application Details
+
+Example Request:
+
+```
+POST /v1/apps/example-go/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Optional parameters:
+
+```
+{
+  "owner": "test"
+}
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.8.0
+Content-Type: application/json
+```
+
+### Retrieve Application Logs
+
+Example Request:
+
+```
+GET /v1/apps/example-go/logs/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Optional URL Query Parameters:
+
+```
+?log_lines=
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: text/plain
+
+"16:51:14 deis[api]: test created initial release\n"
+```
+
+### Run one-off Commands
+
+```
+POST /v1/apps/example-go/run/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{"command": "echo hi"}
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{"rc": 0, "output": "hi\n"}
+```
+
+## Certificates
+
+### List all Certificates
+
+Example Request:
+
+```
+GET /v1/certs HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "common_name": "test.example.com",
+            "expires": "2014-01-01T00:00:00UTC"
+        }
+    ]
+}
+```
+
+### List Certificate Details
+
+Example Request:
+
+```
+GET /v1/certs/test.example.com HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "updated": "2014-01-01T00:00:00UTC",
+    "created": "2014-01-01T00:00:00UTC",
+    "expires": "2015-01-01T00:00:00UTC",
+    "common_name": "test.example.com",
+    "owner": "test",
+    "id": 1
+}
+```
+
+### Create Certificate
+
+Example Request:
+
+```
+POST /v1/certs/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{
+    "certificate": "-----BEGIN CERTIFICATE-----",
+    "key": "-----BEGIN RSA PRIVATE KEY-----"
+}
+```
+
+Optional Parameters:
+
+```
+{
+    "common_name": "test.example.com"
+}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "updated": "2014-01-01T00:00:00UTC",
+    "created": "2014-01-01T00:00:00UTC",
+    "expires": "2015-01-01T00:00:00UTC",
+    "common_name": "test.example.com",
+    "owner": "test",
+    "id": 1
+}
+```
+
+### Destroy a Certificate
+
+Example Request:
+
+```
+DELETE /v1/certs/test.example.com HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+## Containers
+
+### List all Containers
+
+Example Request:
+
+```
+GET /v1/apps/example-go/containers/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "owner": "test",
+            "app": "example-go",
+            "release": "v2",
+            "created": "2014-01-01T00:00:00UTC",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+            "type": "web",
+            "num": 1,
+            "state": "up"
+        }
+    ]
+}
+```
+
+### List all Containers by Type
+
+Example Request:
+
+```
+GET /v1/apps/example-go/containers/web/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "owner": "test",
+            "app": "example-go",
+            "release": "v2",
+            "created": "2014-01-01T00:00:00UTC",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+            "type": "web",
+            "num": 1,
+            "state": "up"
+        }
+    ]
+}
+```
+
+### Restart All Containers
+
+Example Request:
+
+```
+POST /v1/apps/example-go/containers/restart/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+[
+    {
+        "owner": "test",
+        "app": "example-go",
+        "release": "v2",
+        "created": "2014-01-01T00:00:00UTC",
+        "updated": "2014-01-01T00:00:00UTC",
+        "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+        "type": "web",
+        "num": 1,
+        "state": "up"
+    }
+]
+```
+
+### Restart Containers by Type
+
+Example Request:
+
+```
+POST /v1/apps/example-go/containers/web/restart/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+[
+    {
+        "owner": "test",
+        "app": "example-go",
+        "release": "v2",
+        "created": "2014-01-01T00:00:00UTC",
+        "updated": "2014-01-01T00:00:00UTC",
+        "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+        "type": "web",
+        "num": 1,
+        "state": "up"
+    }
+]
+```
+
+### Restart Containers by Type and Number
+
+Example Request:
+
+```
+POST /v1/apps/example-go/containers/web/1/restart/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+[
+    {
+        "owner": "test",
+        "app": "example-go",
+        "release": "v2",
+        "created": "2014-01-01T00:00:00UTC",
+        "updated": "2014-01-01T00:00:00UTC",
+        "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+        "type": "web",
+        "num": 1,
+        "state": "up"
+    }
+]
+```
+
+### Scale Containers
+
+Example Request:
+
+```
+POST /v1/apps/example-go/scale/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{"web": 3}
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+## Configuration
+
+### List Application Configuration
+
+Example Request:
+
+```
+GET /v1/apps/example-go/config/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "owner": "test",
+    "app": "example-go",
+    "values": {
+      "PLATFORM": "deis"
+    },
+    "memory": {},
+    "cpu": {},
+    "tags": {},
+    "created": "2014-01-01T00:00:00UTC",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+### Create new Config
+
+Example Request:
+
+```
+POST /v1/apps/example-go/config/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{"values": {"HELLO": "world", "PLATFORM": "deis"}}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+X-Deis-Release: 3
+
+{
+    "owner": "test",
+    "app": "example-go",
+    "values": {
+        "DEIS_APP": "example-go",
+        "DEIS_RELEASE": "v3",
+        "HELLO": "world",
+        "PLATFORM": "deis"
+
+    },
+    "memory": {},
+    "cpu": {},
+    "tags": {},
+    "created": "2014-01-01T00:00:00UTC",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+### Unset Config Variable
+
+Example Request:
+
+```
+POST /v1/apps/example-go/config/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{"values": {"HELLO": null}}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+X-Deis-Release: 4
+
+{
+    "owner": "test",
+    "app": "example-go",
+    "values": {
+        "DEIS_APP": "example-go",
+        "DEIS_RELEASE": "v4",
+        "PLATFORM": "deis"
+   },
+    "memory": {},
+    "cpu": {},
+    "tags": {},
+    "created": "2014-01-01T00:00:00UTC",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+## Domains
+
+### List Application Domains
+
+Example Request:
+
+```
+GET /v1/apps/example-go/domains/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "app": "example-go",
+            "created": "2014-01-01T00:00:00UTC",
+            "domain": "example.example.com",
+            "owner": "test",
+            "updated": "2014-01-01T00:00:00UTC"
+        }
+    ]
+}
+```
+
+### Add Domain
+
+Example Request:
+
+```
+POST /v1/apps/example-go/domains/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+
+{'domain': 'example.example.com'}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "app": "example-go",
+    "created": "2014-01-01T00:00:00UTC",
+    "domain": "example.example.com",
+    "owner": "test",
+    "updated": "2014-01-01T00:00:00UTC"
+}
+```
+
+### Remove Domain
+
+Example Request:
+
+```
+DELETE /v1/apps/example-go/domains/example.example.com HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+## Builds
+
+### List Application Builds
+
+Example Request:
+
+```
+GET /v1/apps/example-go/builds/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "app": "example-go",
+            "created": "2014-01-01T00:00:00UTC",
+            "dockerfile": "FROM deis/slugrunner RUN mkdir -p /app WORKDIR /app ENTRYPOINT [\"/runner/init\"] ADD slug.tgz /app ENV GIT_SHA 060da68f654e75fac06dbedd1995d5f8ad9084db",
+            "image": "example-go",
+            "owner": "test",
+            "procfile": {
+                "web": "example-go"
+            },
+            "sha": "060da68f",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+        }
+    ]
+}
+```
+
+### Create Application Build
+
+Example Request:
+
+```
+POST /v1/apps/example-go/builds/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{"image": "deis/example-go:latest"}
+```
+
+Optional Parameters:
+
+```
+{
+    "procfile": {
+      "web": "./cmd"
+    }
+}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+X-Deis-Release: 4
+
+{
+    "app": "example-go",
+    "created": "2014-01-01T00:00:00UTC",
+    "dockerfile": "",
+    "image": "deis/example-go:latest",
+    "owner": "test",
+    "procfile": {},
+    "sha": "",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+## Releases
+
+### List Application Releases
+
+Example Request:
+
+```
+GET /v1/apps/example-go/releases/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 3,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "app": "example-go",
+            "build": "202d8e4b-600e-4425-a85c-ffc7ea607f61",
+            "config": "ed637ceb-5d32-44bd-9406-d326a777a513",
+            "created": "2014-01-01T00:00:00UTC",
+            "owner": "test",
+            "summary": "test changed nothing",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+            "version": 3
+        },
+        {
+            "app": "example-go",
+            "build": "202d8e4b-600e-4425-a85c-ffc7ea607f61",
+            "config": "95bd6dea-1685-4f78-a03d-fd7270b058d1",
+            "created": "2014-01-01T00:00:00UTC",
+            "owner": "test",
+            "summary": "test deployed 060da68",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+            "version": 2
+        },
+        {
+            "app": "example-go",
+            "build": null,
+            "config": "95bd6dea-1685-4f78-a03d-fd7270b058d1",
+            "created": "2014-01-01T00:00:00UTC",
+            "owner": "test",
+            "summary": "test created initial release",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+            "version": 1
+        }
+    ]
+}
+```
+
+### List Release Details
+
+Example Request:
+
+```
+GET /v1/apps/example-go/releases/v1/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "app": "example-go",
+    "build": null,
+    "config": "95bd6dea-1685-4f78-a03d-fd7270b058d1",
+    "created": "2014-01-01T00:00:00UTC",
+    "owner": "test",
+    "summary": "test created initial release",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+    "version": 1
+}
+```
+
+### Rollback Release
+
+Example Request:
+
+```
+POST /v1/apps/example-go/releases/rollback/ HTTP/1.1
+Host: deis.example.com
+Content-Type: application/json
+Authorization: token abc123
+
+{"version": 1}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{"version": 5}
+```
+
+## Keys
+
+### List Keys
+
+Example Request:
+
+```
+GET /v1/keys/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "created": "2014-01-01T00:00:00UTC",
+            "id": "test@example.com",
+            "owner": "test",
+            "public": "ssh-rsa <...>",
+            "updated": "2014-01-01T00:00:00UTC",
+            "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+        }
+    ]
+}
+```
+
+### Add Key to User
+
+Example Request:
+
+```
+POST /v1/keys/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+
+{
+    "id": "example",
+    "public": "ssh-rsa <...>"
+}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "created": "2014-01-01T00:00:00UTC",
+    "id": "example",
+    "owner": "example",
+    "public": "ssh-rsa <...>",
+    "updated": "2014-01-01T00:00:00UTC",
+    "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+}
+```
+
+### Remove Key from User
+
+Example Request:
+
+```
+DELETE /v1/keys/example HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+## Permissions
+
+### List Application Permissions
+
+> **note**
+>
+> This does not include the app owner.
+
+Example Request:
+
+```
+GET /v1/apps/example-go/perms/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "users": [
+        "test",
+        "foo"
+    ]
+}
+```
+
+### Create Application Permission
+
+Example Request:
+
+```
+POST /v1/apps/example-go/perms/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+
+{"username": "example"}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+### Remove Application Permission
+
+Example Request:
+
+```
+DELETE /v1/apps/example-go/perms/example HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+### List Administrators
+
+Example Request:
+
+```
+GET /v1/admin/perms/ HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 2,
+    "next": null
+    "previous": null,
+    "results": [
+        {
+            "username": "test",
+            "is_superuser": true
+        },
+        {
+            "username": "foo",
+            "is_superuser": true
+        }
+    ]
+}
+```
+
+### Grant User Administrative Privileges
+
+> **note**
+>
+> This command requires administrative privileges
+
+Example Request:
+
+```
+POST /v1/admin/perms HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+
+{"username": "example"}
+```
+
+Example Response:
+
+```
+HTTP/1.1 201 CREATED
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+### Remove User's Administrative Privileges
+
+> **note**
+>
+> This command requires administrative privileges
+
+Example Request:
+
+```
+DELETE /v1/admin/perms/example HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 204 NO CONTENT
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+```
+
+## Users
+
+### List all users
+
+> **note**
+>
+> This command requires administrative privileges
+
+Example Request:
+
+```
+GET /v1/users HTTP/1.1
+Host: deis.example.com
+Authorization: token abc123
+```
+
+Example Response:
+
+```
+HTTP/1.1 200 OK
+DEIS_API_VERSION: 2.0
+DEIS_PLATFORM_VERSION: 1.12.1
+Content-Type: application/json
+
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "last_login": "2014-10-19T22:01:00.601Z",
+            "is_superuser": true,
+            "username": "test",
+            "first_name": "test",
+            "last_name": "testerson",
+            "email": "test@example.com",
+            "is_staff": true,
+            "is_active": true,
+            "date_joined": "2014-10-19T22:01:00.601Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    ]
+}
+```

--- a/rootfs/api/__init__.py
+++ b/rootfs/api/__init__.py
@@ -2,4 +2,4 @@
 The **api** Django app presents a RESTful web API for interacting with the **deis** system.
 """
 
-__version__ = '1.7.0'
+__version__ = '2.0.0'

--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -49,6 +49,9 @@ def mock_status_ok(*args, **kwargs):
     return resp
 
 
+def mock_none(*args, **kwargs):
+    return None
+
 from .test_api_middleware import *  # noqa
 from .test_app import *  # noqa
 from .test_auth import *  # noqa

--- a/rootfs/api/tests/test_api_middleware.py
+++ b/rootfs/api/tests/test_api_middleware.py
@@ -27,7 +27,7 @@ class APIMiddlewareTest(TestCase):
         Test that when the version header is sent, the request is accepted.
         """
         response = self.client.get(
-            '/v1/apps',
+            '/v2/apps',
             HTTP_DEIS_VERSION=__version__.rsplit('.', 2)[0],
             HTTP_AUTHORIZATION='token {}'.format(self.token),
         )
@@ -40,7 +40,7 @@ class APIMiddlewareTest(TestCase):
         Test that when an improper version header is sent, the request is declined.
         """
         response = self.client.get(
-            '/v1/apps',
+            '/v2/apps',
             HTTP_DEIS_VERSION='1234.5678',
             HTTP_AUTHORIZATION='token {}'.format(self.token),
         )
@@ -50,6 +50,6 @@ class APIMiddlewareTest(TestCase):
         """
         Test that when the version header is not present, the request is accepted.
         """
-        response = self.client.get('/v1/apps',
+        response = self.client.get('/v2/apps',
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)

--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -47,7 +47,7 @@ class AuthTest(TestCase):
             'is_superuser': True,
             'is_staff': True,
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         for key in response.data:
@@ -65,7 +65,7 @@ class AuthTest(TestCase):
         }
         self.assertDictContainsSubset(expected, response.data)
         # test login
-        url = '/v1/auth/login/'
+        url = '/v2/auth/login/'
         payload = urllib.urlencode({'username': username, 'password': password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
@@ -74,7 +74,7 @@ class AuthTest(TestCase):
     @override_settings(REGISTRATION_MODE="disabled")
     def test_auth_registration_disabled(self):
         """test that a new user cannot register when registration is disabled."""
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         submit = {
             'username': 'testuser',
             'password': 'password',
@@ -90,7 +90,7 @@ class AuthTest(TestCase):
     @override_settings(REGISTRATION_MODE="admin_only")
     def test_auth_registration_admin_only_fails_if_not_admin(self):
         """test that a non superuser cannot register when registration is admin only."""
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         submit = {
             'username': 'testuser',
             'password': 'password',
@@ -106,7 +106,7 @@ class AuthTest(TestCase):
     @override_settings(REGISTRATION_MODE="admin_only")
     def test_auth_registration_admin_only_works(self):
         """test that a superuser can register when registration is admin only."""
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
 
         username, password = 'newuser_by_admin', 'password'
         first_name, last_name = 'Otto', 'Test'
@@ -141,7 +141,7 @@ class AuthTest(TestCase):
         }
         self.assertDictContainsSubset(expected, response.data)
         # test login
-        url = '/v1/auth/login/'
+        url = '/v2/auth/login/'
         payload = urllib.urlencode({'username': username, 'password': password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
@@ -150,7 +150,7 @@ class AuthTest(TestCase):
     @override_settings(REGISTRATION_MODE="not_a_mode")
     def test_auth_registration_fails_with_nonexistant_mode(self):
         """test that a registration should fail with a nonexistant mode"""
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         submit = {
             'username': 'testuser',
             'password': 'password',
@@ -191,24 +191,24 @@ class AuthTest(TestCase):
             'is_superuser': False,
             'is_staff': False,
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
 
         # cancel the account
-        url = '/v1/auth/cancel'
+        url = '/v2/auth/cancel'
         user = User.objects.get(username=username)
         token = Token.objects.get(user=user).key
         response = self.client.delete(url,
                                       HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 204)
 
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(other_submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
 
         # normal user can't delete another user
-        url = '/v1/auth/cancel'
+        url = '/v2/auth/cancel'
         other_user = User.objects.get(username=other_username)
         other_token = Token.objects.get(user=other_user).key
         response = self.client.delete(url, json.dumps({'username': self.admin.username}),
@@ -235,11 +235,11 @@ class AuthTest(TestCase):
             'last_name': last_name,
             'email': email,
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         # change password
-        url = '/v1/auth/passwd'
+        url = '/v2/auth/passwd'
         user = User.objects.get(username=username)
         token = Token.objects.get(user=user).key
         submit = {
@@ -259,7 +259,7 @@ class AuthTest(TestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 200)
         # test login with old password
-        url = '/v1/auth/login/'
+        url = '/v2/auth/login/'
         payload = urllib.urlencode({'username': username, 'password': password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
@@ -275,7 +275,7 @@ class AuthTest(TestCase):
         Test that an administrator can change a user's password, while a regular user cannot.
         """
         # change password
-        url = '/v1/auth/passwd'
+        url = '/v2/auth/passwd'
         old_password = self.user1.password
         new_password = 'password'
         submit = {
@@ -286,7 +286,7 @@ class AuthTest(TestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
         self.assertEqual(response.status_code, 200)
         # test login with old password
-        url = '/v1/auth/login/'
+        url = '/v2/auth/login/'
         payload = urllib.urlencode({'username': self.user1.username, 'password': old_password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
@@ -298,7 +298,7 @@ class AuthTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # Non-admins can't change another user's password
         submit['password'], submit['new_password'] = submit['new_password'], old_password
-        url = '/v1/auth/passwd'
+        url = '/v2/auth/passwd'
         response = self.client.post(url, json.dumps(submit), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.user2_token))
         self.assertEqual(response.status_code, 403)
@@ -307,7 +307,7 @@ class AuthTest(TestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(self.user1_token))
         self.assertEqual(response.status_code, 200)
         # test login with new password
-        url = '/v1/auth/login/'
+        url = '/v2/auth/login/'
         payload = urllib.urlencode({'username': self.user1.username, 'password': old_password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
@@ -316,7 +316,7 @@ class AuthTest(TestCase):
     def test_regenerate(self):
         """ Test that token regeneration works"""
 
-        url = '/v1/auth/tokens/'
+        url = '/v2/auth/tokens/'
 
         response = self.client.post(url, '{}', content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.admin_token))

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -33,12 +33,12 @@ class BuildTest(TransactionTestCase):
         """
         Test that a null build is created and that users can post new builds
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # check to see that no initial build was created
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -52,14 +52,14 @@ class BuildTest(TransactionTestCase):
         build1 = response.data
         self.assertEqual(response.data['image'], body['image'])
         # read the build
-        url = "/v1/apps/{app_id}/builds/{build_id}".format(**locals())
+        url = "/v2/apps/{app_id}/builds/{build_id}".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         build2 = response.data
         self.assertEqual(build1, build2)
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -80,12 +80,12 @@ class BuildTest(TransactionTestCase):
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
         body = {'id': 'test'}
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, json.dumps(body),
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         # post an image as a build
-        url = "/v1/apps/test/builds".format(**locals())
+        url = "/v2/apps/test/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -104,17 +104,17 @@ class BuildTest(TransactionTestCase):
 
     @mock.patch('requests.post', mock_status_ok)
     def test_build_default_containers(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post an image as a build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers/cmd".format(**locals())
+        url = "/v2/apps/{app_id}/containers/cmd".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -123,19 +123,19 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['num'], 1)
         # start with a new app
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build with procfile
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example',
                 'sha': 'a'*40,
                 'dockerfile': "FROM scratch"}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers/cmd".format(**locals())
+        url = "/v2/apps/{app_id}/containers/cmd".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -144,12 +144,12 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['num'], 1)
         # start with a new app
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build with procfile
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example',
                 'sha': 'a'*40,
                 'dockerfile': "FROM scratch",
@@ -157,7 +157,7 @@ class BuildTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers/cmd".format(**locals())
+        url = "/v2/apps/{app_id}/containers/cmd".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -166,12 +166,12 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(container['type'], 'cmd')
         self.assertEqual(container['num'], 1)
         # start with a new app
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build with procfile
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example',
                 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js',
@@ -179,7 +179,7 @@ class BuildTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers/web".format(**locals())
+        url = "/v2/apps/{app_id}/containers/web".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -191,12 +191,12 @@ class BuildTest(TransactionTestCase):
     @mock.patch('requests.post', mock_status_ok)
     def test_build_str(self):
         """Test the text representation of a build."""
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -213,12 +213,12 @@ class BuildTest(TransactionTestCase):
         # create app as non-admin
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user).key
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build as admin
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -236,7 +236,7 @@ class BuildTest(TransactionTestCase):
         requests should return a 403.
         """
         app_id = 'autotest'
-        url = '/v1/apps'
+        url = '/v2/apps'
         body = {'id': app_id}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -254,12 +254,12 @@ class BuildTest(TransactionTestCase):
         After the first initial deploy, if the containers are scaled down to zero,
         they should stay that way on a new release.
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example',
                 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js',
@@ -267,19 +267,19 @@ class BuildTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers/web".format(**locals())
+        url = "/v2/apps/{app_id}/containers/web".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale to zero
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
         # post another build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example',
                 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js',
@@ -287,7 +287,7 @@ class BuildTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers/web".format(**locals())
+        url = "/v2/apps/{app_id}/containers/web".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)

--- a/rootfs/api/tests/test_certificate.py
+++ b/rootfs/api/tests/test_certificate.py
@@ -20,7 +20,7 @@ class CertificateTest(TestCase):
         self.token = Token.objects.get(user=self.user).key
         self.user2 = User.objects.get(username='autotest2')
         self.token2 = Token.objects.get(user=self.user).key
-        self.url = '/v1/certs'
+        self.url = '/v2/certs'
         self.app = App.objects.create(owner=self.user, id='test-app')
         self.key = """-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAwyLIwjpUQkAmh/z6JvQMAtvNu/dBuCt+R8cnQMEw4VglglMw
@@ -121,7 +121,7 @@ thejiQz0ThCMBw7QMpVOiSvYAlQG0ATsRYwdTDqENIWKlerOLCSuxmbqe8XeDKhq
         Certificate.objects.create(owner=self.user,
                                    common_name='autotest.example.com',
                                    certificate=self.autotest_example_com_cert)
-        url = '/v1/certs/autotest.example.com'
+        url = '/v2/certs/autotest.example.com'
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
         # deleting a wildcard cert should work too (even though they're unsupported right now)
@@ -129,6 +129,6 @@ thejiQz0ThCMBw7QMpVOiSvYAlQG0ATsRYwdTDqENIWKlerOLCSuxmbqe8XeDKhq
         Certificate.objects.create(owner=self.user,
                                    common_name='*.example.com',
                                    certificate=self.autotest_example_com_cert)
-        url = '/v1/certs/*.example.com'
+        url = '/v2/certs/*.example.com'
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -56,7 +56,7 @@ class ConfigTest(TransactionTestCase):
     def setUp(self):
         self.user = User.objects.get(username='autotest')
         self.token = Token.objects.get(user=self.user).key
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         self.app = App.objects.all()[0]
@@ -67,12 +67,12 @@ class ConfigTest(TransactionTestCase):
         Test that config is auto-created for a new app and that
         config can be updated using a PATCH
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # check to see that an initial/empty config was created
-        url = "/v1/apps/{app_id}/config".format(**locals())
+        url = "/v2/apps/{app_id}/config".format(**locals())
         response = self.client.get(url,
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
@@ -137,10 +137,10 @@ class ConfigTest(TransactionTestCase):
     def test_response_data(self):
         """Test that the serialized response contains only relevant data."""
         body = {'id': 'test'}
-        response = self.client.post('/v1/apps', json.dumps(body),
+        response = self.client.post('/v2/apps', json.dumps(body),
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
-        url = "/v1/apps/test/config"
+        url = "/v2/apps/test/config"
         # set an initial config value
         body = {'values': json.dumps({'PORT': '5000'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -162,10 +162,10 @@ class ConfigTest(TransactionTestCase):
     def test_response_data_types_converted(self):
         """Test that config data is converted into the correct type."""
         body = {'id': 'test'}
-        response = self.client.post('/v1/apps', json.dumps(body),
+        response = self.client.post('/v2/apps', json.dumps(body),
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
-        url = "/v1/apps/test/config"
+        url = "/v2/apps/test/config"
 
         body = {'values': json.dumps({'PORT': 5000}), 'cpu': json.dumps({'web': '1024'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -195,11 +195,11 @@ class ConfigTest(TransactionTestCase):
         """
         Test that config sets on the same key function properly
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = "/v1/apps/{app_id}/config".format(**locals())
+        url = "/v2/apps/{app_id}/config".format(**locals())
         # set an initial config value
         body = {'values': json.dumps({'PORT': '5000'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -219,11 +219,11 @@ class ConfigTest(TransactionTestCase):
         """
         Test that config sets with unicode values are accepted.
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = "/v1/apps/{app_id}/config".format(**locals())
+        url = "/v2/apps/{app_id}/config".format(**locals())
         # set an initial config value
         body = {'values': json.dumps({'POWERED_BY': 'Деис'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -257,11 +257,11 @@ class ConfigTest(TransactionTestCase):
         """Test that valid config keys are accepted.
         """
         keys = ("FOO", "_foo", "f001", "FOO_BAR_BAZ_")
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = '/v1/apps/{app_id}/config'.format(**locals())
+        url = '/v2/apps/{app_id}/config'.format(**locals())
         for k in keys:
             body = {'values': json.dumps({k: "testvalue"})}
             resp = self.client.post(
@@ -275,11 +275,11 @@ class ConfigTest(TransactionTestCase):
         """Test that invalid config keys are rejected.
         """
         keys = ("123", "../../foo", "FOO/", "FOO-BAR")
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = '/v1/apps/{app_id}/config'.format(**locals())
+        url = '/v2/apps/{app_id}/config'.format(**locals())
         for k in keys:
             body = {'values': json.dumps({k: "testvalue"})}
             resp = self.client.post(
@@ -294,11 +294,11 @@ class ConfigTest(TransactionTestCase):
         """
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user).key
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = "/v1/apps/{app_id}/config".format(**locals())
+        url = "/v2/apps/{app_id}/config".format(**locals())
         # set an initial config value
         body = {'values': json.dumps({'PORT': '5000'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -313,11 +313,11 @@ class ConfigTest(TransactionTestCase):
         Test that limit is auto-created for a new app and that
         limits can be updated using a PATCH
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = '/v1/apps/{app_id}/config'.format(**locals())
+        url = '/v2/apps/{app_id}/config'.format(**locals())
         # check default limit
         response = self.client.get(url, content_type='application/json',
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -400,11 +400,11 @@ class ConfigTest(TransactionTestCase):
         """
         Test that CPU limits can be set
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = '/v1/apps/{app_id}/config'.format(**locals())
+        url = '/v2/apps/{app_id}/config'.format(**locals())
         # check default limit
         response = self.client.get(url, content_type='application/json',
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -471,11 +471,11 @@ class ConfigTest(TransactionTestCase):
         """
         Test that tags can be set on an application
         """
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
-        url = '/v1/apps/{app_id}/config'.format(**locals())
+        url = '/v2/apps/{app_id}/config'.format(**locals())
         # check default
         response = self.client.get(url, content_type='application/json',
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -559,7 +559,7 @@ class ConfigTest(TransactionTestCase):
         requests should return a 403.
         """
         app_id = 'autotest'
-        base_url = '/v1/apps'
+        base_url = '/v2/apps'
         body = {'id': app_id}
         response = self.client.post(base_url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -573,7 +573,7 @@ class ConfigTest(TransactionTestCase):
 
     def _test_app_healthcheck(self):
         # post a new build, expecting it to pass as usual
-        url = "/v1/apps/{self.app}/builds".format(**locals())
+        url = "/v2/apps/{self.app}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -581,7 +581,7 @@ class ConfigTest(TransactionTestCase):
         # mock out the etcd client
         api.models._etcd_client = MockEtcdClient(self.app)
         # set an initial healthcheck url.
-        url = "/v1/apps/{self.app}/config".format(**locals())
+        url = "/v2/apps/{self.app}/config".format(**locals())
         body = {'values': json.dumps({'HEALTHCHECK_URL': '/'})}
         return self.client.post(url, json.dumps(body), content_type='application/json',
                                 HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -634,7 +634,7 @@ seconds".format(self.app.id)
         Ensure that when a healthcheck fails, a backoff strategy is used before trying again.
         """
         # post a new build, expecting it to pass as usual
-        url = "/v1/apps/{self.app}/builds".format(**locals())
+        url = "/v2/apps/{self.app}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -642,7 +642,7 @@ seconds".format(self.app.id)
         # mock out the etcd client
         api.models._etcd_client = MockEtcdClient(self.app)
         # set an initial healthcheck url.
-        url = "/v1/apps/{self.app}/config".format(**locals())
+        url = "/v2/apps/{self.app}/config".format(**locals())
         body = {'values': json.dumps({'HEALTHCHECK_URL': '/'})}
         return self.client.post(url, json.dumps(body), content_type='application/json',
                                 HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -656,7 +656,7 @@ seconds".format(self.app.id)
         x is the number of seconds in the initial timeout.
         """
         # post a new build, expecting it to pass as usual
-        url = "/v1/apps/{self.app}/builds".format(**locals())
+        url = "/v2/apps/{self.app}/builds".format(**locals())
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -664,7 +664,7 @@ seconds".format(self.app.id)
         # mock out the etcd client
         api.models._etcd_client = MockEtcdClient(self.app)
         # set an initial healthcheck url.
-        url = "/v1/apps/{self.app}/config".format(**locals())
+        url = "/v2/apps/{self.app}/config".format(**locals())
         body = {'values': json.dumps({'HEALTHCHECK_URL': '/'})}
         return self.client.post(url, json.dumps(body), content_type='application/json',
                                 HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -672,7 +672,7 @@ seconds".format(self.app.id)
         # mock_time; one for the call in the code, and one for this invocation.
         mock_time.assert_called_with(0)
         app = App.objects.all()[0]
-        url = "/v1/apps/{app}/config".format(**locals())
+        url = "/v2/apps/{app}/config".format(**locals())
         body = {'values': json.dumps({'HEALTHCHECK_INITIAL_DELAY': 10})}
         self.client.post(url, json.dumps(body), content_type='application/json',
                          HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -687,7 +687,7 @@ seconds".format(self.app.id)
         """
         self._test_app_healthcheck()
         app = App.objects.all()[0]
-        url = "/v1/apps/{app}/config".format(**locals())
+        url = "/v2/apps/{app}/config".format(**locals())
         body = {'values': json.dumps({'HEALTHCHECK_TIMEOUT': 10})}
         self.client.post(url, json.dumps(body), content_type='application/json',
                          HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/rootfs/api/tests/test_key.py
+++ b/rootfs/api/tests/test_key.py
@@ -66,7 +66,7 @@ class KeyTest(TestCase):
         """
         Test that a user can add, remove and manage their SSH public keys
         """
-        url = '/v1/keys'
+        url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -75,7 +75,7 @@ class KeyTest(TestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
-        url = '/v1/keys/{key_id}'.format(**locals())
+        url = '/v2/keys/{key_id}'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body['id'], response.data['id'])
@@ -87,7 +87,7 @@ class KeyTest(TestCase):
         """
         Test that a user cannot add invalid SSH public keys
         """
-        url = '/v1/keys'
+        url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -108,7 +108,7 @@ class KeyTest(TestCase):
         """
         Test that a user cannot add a duplicate key
         """
-        url = '/v1/keys'
+        url = '/v2/keys'
         body = {'id': 'mykey@box.local', 'public': pubkey}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -134,7 +134,7 @@ class KeyTest(TestCase):
 
     def test_rsa_key_str(self):
         """Test the text representation of a key"""
-        url = '/v1/keys'
+        url = '/v2/keys'
         body = {'id': 'autotest', 'public':
                 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDzqPAwHN70xsB0LXG//KzO'
                 'gcPikyhdN/KRc4x3j/RA0pmFj63Ywv0PJ2b1LcMSqfR8F11WBlrW8c9xFua0'

--- a/rootfs/api/tests/test_perm.py
+++ b/rootfs/api/tests/test_perm.py
@@ -18,7 +18,7 @@ class TestAdminPerms(TestCase):
             'password': password,
             'email': email,
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
@@ -30,7 +30,7 @@ class TestAdminPerms(TestCase):
             'password': password,
             'email': email,
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
@@ -41,13 +41,13 @@ class TestAdminPerms(TestCase):
             'password': 'password',
             'email': 'autotest@deis.io',
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
         user = User.objects.get(username='firstuser')
         token = Token.objects.get(user=user).key
-        response = self.client.get('/v1/admin/perms', content_type='application/json',
+        response = self.client.get('/v2/admin/perms', content_type='application/json',
                                    HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
@@ -59,13 +59,13 @@ class TestAdminPerms(TestCase):
             'password': 'password',
             'email': 'autotest@deis.io',
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
         user = User.objects.get(username='seconduser')
         token = Token.objects.get(user=user).key
-        response = self.client.get('/v1/admin/perms', content_type='application/json',
+        response = self.client.get('/v2/admin/perms', content_type='application/json',
                                    HTTP_AUTHORIZATION='token {}'.format(token))
         self.assertEqual(response.status_code, 403)
         self.assertIn('You do not have permission', response.data['detail'])
@@ -76,7 +76,7 @@ class TestAdminPerms(TestCase):
             'password': 'password',
             'email': 'autotest@deis.io',
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
@@ -85,14 +85,14 @@ class TestAdminPerms(TestCase):
             'password': 'password',
             'email': 'autotest@deis.io',
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
         user = User.objects.get(username='first')
         token = Token.objects.get(user=user).key
         # grant user 2 the superuser perm
-        url = '/v1/admin/perms'
+        url = '/v2/admin/perms'
         body = {'username': 'second'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(token))
@@ -108,7 +108,7 @@ class TestAdminPerms(TestCase):
             'password': 'password',
             'email': 'autotest@deis.io',
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data['is_superuser'])
@@ -117,14 +117,14 @@ class TestAdminPerms(TestCase):
             'password': 'password',
             'email': 'autotest@deis.io',
         }
-        url = '/v1/auth/register'
+        url = '/v2/auth/register'
         response = self.client.post(url, json.dumps(submit), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertFalse(response.data['is_superuser'])
         user = User.objects.get(username='first')
         token = Token.objects.get(user=user).key
         # grant user 2 the superuser perm
-        url = '/v1/admin/perms'
+        url = '/v2/admin/perms'
         body = {'username': 'second'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(token))
@@ -152,17 +152,17 @@ class TestAppPerms(TestCase):
 
     def test_create(self):
         # check that user 1 sees her lone app and user 2's app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         app_id = response.data['results'][0]['id']
         # check that user 2 can only see his app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
         self.assertEqual(len(response.data['results']), 1)
         # check that user 2 can't see any of the app's builds, configs,
         # containers, limits, or releases
         for model in ['builds', 'config', 'containers', 'releases']:
-            response = self.client.get("/v1/apps/{}/{}/".format(app_id, model),
+            response = self.client.get("/v2/apps/{}/{}/".format(app_id, model),
                                        HTTP_AUTHORIZATION='token {}'.format(self.token2))
             msg = "Failed: status '%s', and data '%s'" % (response.status_code, response.data)
             self.assertEqual(response.status_code, 403, msg=msg)
@@ -170,30 +170,30 @@ class TestAppPerms(TestCase):
                              'You do not have permission to perform this action.', msg=msg)
         # TODO: test that git pushing to the app fails
         # give user 2 permission to user 1's app
-        url = "/v1/apps/{}/perms".format(app_id)
+        url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         # check that user 2 can see the app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         # check that user 2 sees (empty) results now for builds, containers,
         # and releases. (config and limit will still give 404s since we didn't
         # push a build here.)
         for model in ['builds', 'containers', 'releases']:
-            response = self.client.get("/v1/apps/{}/{}/".format(app_id, model),
+            response = self.client.get("/v2/apps/{}/{}/".format(app_id, model),
                                        HTTP_AUTHORIZATION='token {}'.format(self.token2))
             self.assertEqual(len(response.data['results']), 0)
         # TODO:  check that user 2 can git push the app
 
     def test_create_errors(self):
         # check that user 1 sees her lone app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
         app_id = response.data['results'][0]['id']
         # check that user 2 can't create a permission
-        url = "/v1/apps/{}/perms".format(app_id)
+        url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token2))
@@ -201,25 +201,25 @@ class TestAppPerms(TestCase):
 
     def test_delete(self):
         # give user 2 permission to user 1's app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
         app_id = response.data['results'][0]['id']
-        url = "/v1/apps/{}/perms".format(app_id)
+        url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         # check that user 2 can see the app as well as his own
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         # delete permission to user 1's app
-        url = "/v1/apps/{}/perms/{}".format(app_id, 'autotest-2')
+        url = "/v2/apps/{}/perms/{}".format(app_id, 'autotest-2')
         response = self.client.delete(url, content_type='application/json',
                                       HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
         self.assertIsNone(response.data)
         # check that user 2 can only see his app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token2))
         self.assertEqual(len(response.data['results']), 1)
         # delete permission to user 1's app again, expecting an error
         response = self.client.delete(url, content_type='application/json',
@@ -228,34 +228,34 @@ class TestAppPerms(TestCase):
 
     def test_list(self):
         # check that user 1 sees her lone app and user 2's app
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         app_id = response.data['results'][0]['id']
         # create a new object permission
-        url = "/v1/apps/{}/perms".format(app_id)
+        url = "/v2/apps/{}/perms".format(app_id)
         body = {'username': 'autotest-2'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         # list perms on the app
         response = self.client.get(
-            "/v1/apps/{}/perms".format(app_id), content_type='application/json',
+            "/v2/apps/{}/perms".format(app_id), content_type='application/json',
             HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.data, {'users': ['autotest-2']})
 
     def test_admin_can_list(self):
         """Check that an administrator can list an app's perms"""
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
 
     def test_list_errors(self):
-        response = self.client.get('/v1/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
+        response = self.client.get('/v2/apps', HTTP_AUTHORIZATION='token {}'.format(self.token))
         app_id = response.data['results'][0]['id']
         # login as user 2, list perms on the app
         response = self.client.get(
-            "/v1/apps/{}/perms".format(app_id), content_type='application/json',
+            "/v2/apps/{}/perms".format(app_id), content_type='application/json',
             HTTP_AUTHORIZATION='token {}'.format(self.token2))
         self.assertEqual(response.status_code, 403)
 
@@ -267,7 +267,7 @@ class TestAppPerms(TestCase):
         requests should return a 404.
         """
         app_id = 'autotest'
-        url = '/v1/apps'
+        url = '/v2/apps'
         body = {'id': app_id}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -287,7 +287,7 @@ class TestAppPerms(TestCase):
         owner_token = self.token
         collab = self.user2
         collab_token = self.token2
-        url = '/v1/apps/{}/perms'.format(app_id)
+        url = '/v2/apps/{}/perms'.format(app_id)
         # Share app with collaborator
         body = {'username': collab.username}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -314,6 +314,6 @@ class TestAppPerms(TestCase):
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(collab_token))
         self.assertEqual(response.status_code, 403)
         # Collaborator can delete themselves
-        url = '/v1/apps/{}/perms/{}'.format(app_id, collab.username)
+        url = '/v2/apps/{}/perms/{}'.format(app_id, collab.username)
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(collab_token))
         self.assertEqual(response.status_code, 204)

--- a/rootfs/api/tests/test_scheduler.py
+++ b/rootfs/api/tests/test_scheduler.py
@@ -42,23 +42,23 @@ class SchedulerTest(TransactionTestCase):
         settings.SSH_PRIVATE_KEY = ''
 
     def test_create_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale to zero for consistency
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -66,7 +66,7 @@ class SchedulerTest(TransactionTestCase):
         # let's get chaotic
         chaos.CREATE_ERROR_RATE = 0.5
         # scale up but expect a 503
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 20}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -74,29 +74,29 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(response.data, {'detail': 'aborting, failed to create some containers'})
         self.assertEqual(response.get('content-type'), 'application/json')
         # inspect broken containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 0)
 
     def test_start_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale to zero for consistency
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -104,13 +104,13 @@ class SchedulerTest(TransactionTestCase):
         # let's get chaotic
         chaos.START_ERROR_RATE = 0.5
         # scale up, which will allow some crashed containers
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 20}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
         # inspect broken containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 20)
@@ -119,23 +119,23 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(states, set(['crashed', 'up']))
 
     def test_restart_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale up, which will allow some crashed containers
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 20, 'worker': 20}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -144,13 +144,13 @@ class SchedulerTest(TransactionTestCase):
         chaos.STOP_ERROR_RATE = 0.5
         chaos.START_ERROR_RATE = 0.5
         # reboot the web processes
-        url = "/v1/apps/{app_id}/containers/web/restart".format(**locals())
+        url = "/v2/apps/{app_id}/containers/web/restart".format(**locals())
         response = self.client.post(url,
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200, response.data)
         # inspect broken containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['count'], 40)
@@ -163,7 +163,7 @@ class SchedulerTest(TransactionTestCase):
         # start fresh
         chaos.STOP_ERROR_RATE = 0.0
         chaos.START_ERROR_RATE = 0.0
-        url = "/v1/apps/{app_id}/containers/web/restart".format(**locals())
+        url = "/v2/apps/{app_id}/containers/web/restart".format(**locals())
         response = self.client.post(url,
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -171,13 +171,13 @@ class SchedulerTest(TransactionTestCase):
         chaos.STOP_ERROR_RATE = 0.5
         chaos.START_ERROR_RATE = 0.5
         # reboot ALL the containers!
-        url = "/v1/apps/{app_id}/containers/restart".format(**locals())
+        url = "/v2/apps/{app_id}/containers/restart".format(**locals())
         response = self.client.post(url,
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         # inspect broken containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 40)
@@ -188,35 +188,35 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(types, set(['web', 'worker']))
 
     def test_destroy_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale up
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 20}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 20)
         # let's get chaotic
         chaos.DESTROY_ERROR_RATE = 0.5
         # scale to zero but expect a 503
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 0}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -224,7 +224,7 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(response.data, {'detail': 'aborting, failed to destroy some containers'})
         self.assertEqual(response.get('content-type'), 'application/json')
         # inspect broken containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         states = set([c['state'] for c in response.data['results']])
@@ -232,7 +232,7 @@ class SchedulerTest(TransactionTestCase):
         # make sure we can cleanup after enough tries
         containers = 20
         for _ in xrange(100):
-            url = "/v1/apps/{app_id}/scale".format(**locals())
+            url = "/v2/apps/{app_id}/scale".format(**locals())
             body = {'web': 0}
             response = self.client.post(url, json.dumps(body), content_type='application/json',
                                         HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -244,39 +244,39 @@ class SchedulerTest(TransactionTestCase):
                                                        'destroy some containers'})
             self.assertEqual(response.get('content-type'), 'application/json')
             # inspect broken containers
-            url = "/v1/apps/{app_id}/containers".format(**locals())
+            url = "/v2/apps/{app_id}/containers".format(**locals())
             response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
             self.assertEqual(response.status_code, 200)
             containers = len(response.data['results'])
 
     def test_build_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         # inspect builds
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # inspect releases
-        url = "/v1/apps/{app_id}/releases".format(**locals())
+        url = "/v2/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale up
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 20}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -285,7 +285,7 @@ class SchedulerTest(TransactionTestCase):
         chaos.CREATE_ERROR_RATE = 0.5
         chaos.START_ERROR_RATE = 0.5
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'b'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
@@ -294,12 +294,12 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(response.data, {'detail': 'aborting, failed to create some containers'})
         self.assertEqual(response.get('content-type'), 'application/json')
         # inspect releases
-        url = "/v1/apps/{app_id}/releases".format(**locals())
+        url = "/v2/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         # inspect containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 20)
@@ -308,28 +308,28 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(states, set(['up']))
 
     def test_config_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         # inspect releases
-        url = "/v1/apps/{app_id}/releases".format(**locals())
+        url = "/v2/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # scale up
-        url = "/v1/apps/{app_id}/scale".format(**locals())
+        url = "/v2/apps/{app_id}/scale".format(**locals())
         body = {'web': 20}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -338,7 +338,7 @@ class SchedulerTest(TransactionTestCase):
         chaos.CREATE_ERROR_RATE = 0.5
         chaos.START_ERROR_RATE = 0.5
         # post a new config
-        url = "/v1/apps/{app_id}/config".format(**locals())
+        url = "/v2/apps/{app_id}/config".format(**locals())
         body = {'values': json.dumps({'NEW_URL1': 'http://localhost:8080/'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -346,12 +346,12 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(response.data, {'detail': 'aborting, failed to create some containers'})
         self.assertEqual(response.get('content-type'), 'application/json')
         # inspect releases
-        url = "/v1/apps/{app_id}/releases".format(**locals())
+        url = "/v2/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
         # inspect containers
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 20)
@@ -360,35 +360,35 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(states, set(['up']))
 
     def test_run_chaos(self):
-        url = '/v1/apps'
+        url = '/v2/apps'
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         app_id = response.data['id']
         # post a new build
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         body = {'image': 'autotest/example', 'sha': 'a'*40,
                 'procfile': json.dumps({'web': 'node server.js', 'worker': 'node worker.js'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         # inspect builds
-        url = "/v1/apps/{app_id}/builds".format(**locals())
+        url = "/v2/apps/{app_id}/builds".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # inspect releases
-        url = "/v1/apps/{app_id}/releases".format(**locals())
+        url = "/v2/apps/{app_id}/releases".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 2)
-        url = "/v1/apps/{app_id}/containers".format(**locals())
+        url = "/v2/apps/{app_id}/containers".format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         # block all create operations
         chaos.CREATE_ERROR_RATE = 1
         # make sure the run fails with a 503
-        url = '/v1/apps/{app_id}/run'.format(**locals())
+        url = '/v2/apps/{app_id}/run'.format(**locals())
         body = {'command': 'ls -al'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/rootfs/api/tests/test_users.py
+++ b/rootfs/api/tests/test_users.py
@@ -12,7 +12,7 @@ class TestUsers(TestCase):
     fixtures = ['tests.json']
 
     def test_super_user_can_list(self):
-        url = '/v1/users/'
+        url = '/v2/users/'
 
         user = User.objects.get(username='autotest')
         token = Token.objects.get(user=user)
@@ -24,7 +24,7 @@ class TestUsers(TestCase):
         self.assertEqual(len(response.data['results']), 3)
 
     def test_non_super_user_cannot_list(self):
-        url = '/v1/users/'
+        url = '/v2/users/'
 
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user)

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -226,13 +226,12 @@ class AppViewSet(BaseDeisViewSet):
     def run(self, request, **kwargs):
         app = self.get_object()
         try:
-            output_and_rc = app.run(self.request.user, request.data['command'])
+            rc, output = app.run(self.request.user, request.data['command'])
         except EnvironmentError as e:
             return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except RuntimeError as e:
             return Response({'detail': str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
-        return Response(output_and_rc, status=status.HTTP_200_OK,
-                        content_type='text/plain')
+        return Response({'rc': rc, 'output': str(output)})
 
     def update(self, request, **kwargs):
         app = self.get_object()

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -160,7 +160,7 @@ AUTHENTICATION_BACKENDS = (
 )
 
 ANONYMOUS_USER_ID = -1
-LOGIN_URL = '/v1/auth/login/'
+LOGIN_URL = '/v2/auth/login/'
 LOGIN_REDIRECT_URL = '/'
 
 SOUTH_TESTS_MIGRATE = False

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -17,7 +17,7 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^v1/', include('api.urls')),
+    url(r'^v2/', include('api.urls')),
 )
 
 if settings.WEB_ENABLED:


### PR DESCRIPTION
This is a port of deis/deis#3999 and issue deis/deis#3988 to workflow.

Since this is a backwards incompatible change, I bumped the api to version v2 and updated docs.
Is bumping to 2.0 ok? Is there a version number you would prefer? Should I not bump the version at all yet?

Sorry, I'm not very clued in to v2 yet, but I'd love to see this change go in because muti-type arrays don't play well with the golang client and are pretty evil :smiling_imp:, this was also the way the command was originally documented (though not implemented).

If this is merged, then the controller hooks in builder would also need to update urls to V2.

Fixes #59