### PR TITLE
feat(travis): upload docs and client to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,18 @@ install:
   - GLIDE_HOME=/home/travis/.glide make -C client bootstrap
 script:
   - make test
-  - make -C client/ test
-  - make -C docs/ test
+  - make -C client/ build test
+  - make -C docs/ build test
 deploy:
   provider: script
+  # ensure client/doc builds aren't removed
+  # see https://docs.travis-ci.com/user/deployment/#Uploading-Files
+  skip_cleanup: true
   script: _scripts/deploy.sh
   on:
     branch: master
+addons:
+  artifacts:
+    paths:
+      - client/deis
+      - docs/_build

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ $ kubectl get pods --namespace=deis
 Once this is done, you can SSH into the minion running the controller and run the following:
 
 ```
-$ curl -sSL http://deis.io/deis-cli/install.sh | sh
+$ curl -sSL https://s3-us-west-1.amazonaws.com/bacongobbler/bacongobbler/workflow/19/19.1/client/deis
+$ chmod 755 deis
 $ sudo mv deis /bin
 $ kubectl get service --namespace=deis deis-workflow
 $ deis register 10.247.59.157 # or the appropriate CLUSTER_IP
@@ -49,6 +50,12 @@ Creating Application... done, created madras-radiator
 $ deis pull deis/example-go -a madras-radiator
 Creating build... ..o
 ```
+
+If you want to retrieve the latest client build, check
+[the latest builds on Travis CI](https://travis-ci.org/deis/workflow/builds), notice the last build
+number that went green and use the following URL to retrieve the client build:
+
+    <https://s3-us-west-1.amazonaws.com/get-deis/deis/workflow/$BUILD_NUM/$BUILD_NUM.1/client/deis>
 
 If you want to hack on a new feature, build the deis/workflow image and push it to a Docker
 registry. The `$DEIS_REGISTRY` environment variable must point to a registry accessible to your


### PR DESCRIPTION
This change uses Travis CI's artifact feature to store build information
in S3. Specifically we'd like a client and a doc build so that we can test
and view changes for a specific build with these artifacts, as the rest of
the build artifacts are Docker images, uploaded to Quay.io and DockerHub.

We need to some new environment variables to the workflow job in order for this to work:

 - ARTIFACTS_KEY
 - ARTIFACTS_SECRET
 - ARTIFACTS_BUCKET
 - ARTIFACTS_S3_REGION

closes #61