### PR TITLE
feat(client): use unix pipes with config:push

### DIFF
--- a/client/cmd/config.go
+++ b/client/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -202,11 +203,25 @@ func ConfigPull(appID string, interactive bool, overwrite bool) error {
 }
 
 // ConfigPush pushes an app's config from a file.
-func ConfigPush(appID string, fileName string) error {
-	contents, err := ioutil.ReadFile(fileName)
+func ConfigPush(appID, fileName string) error {
+	stat, err := os.Stdin.Stat()
 
 	if err != nil {
 		return err
+	}
+
+	var contents []byte
+
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		buffer := new(bytes.Buffer)
+		buffer.ReadFrom(os.Stdin)
+		contents = buffer.Bytes()
+	} else {
+		contents, err = ioutil.ReadFile(fileName)
+
+		if err != nil {
+			return err
+		}
 	}
 
 	config := strings.Split(string(contents), "\n")

--- a/client/parser/config.go
+++ b/client/parser/config.go
@@ -152,8 +152,9 @@ func configPush(argv []string) error {
 	usage := `
 Sets environment variables for an application.
 
-The environment is read from <path>. This file can be read by foreman
-to load the local environment for your app.
+This file can be read by foreman
+to load the local environment for your app. The file should be piped via
+stdin, 'deis config:push < .env', or using the --path option.
 
 Usage: deis config:push [options]
 


### PR DESCRIPTION
This was briefly discussed as a V2 thing in deis/deis#4675 and deis/deis#4697.

I personally like it cause it's more unixy, but I understand if this is rejected because this is really a personal preference thing :smiley:.

If there is interest I will make the same change for `config:pull`.