### PR TITLE
fix(k8s.py): access API server by IP address

### DIFF
--- a/rootfs/scheduler/k8s.py
+++ b/rootfs/scheduler/k8s.py
@@ -132,7 +132,10 @@ class KubeHTTPClient(AbstractSchedulerClient):
             'Authorization': 'Bearer ' + token,
             'Content-Type': 'application/json',
         }
-        session.verify = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        # TODO: accessing the k8s api server by IP address rather than hostname avoids
+        # intermittent DNS errors, but at the price of disabling cert verification.
+        # session.verify = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        session.verify = False
         self.session = session
 
     def _api(self, tmpl, *args):

--- a/rootfs/templates/confd_settings.py
+++ b/rootfs/templates/confd_settings.py
@@ -1,10 +1,14 @@
+import os
+
 # security keys and auth tokens
 SECRET_KEY = '{{ getv "/deis/controller/secretKey" }}'
 BUILDER_KEY = '{{ getv "/deis/controller/builderKey" }}'
 
 # scheduler settings
 SCHEDULER_MODULE = 'scheduler.k8s'
-SCHEDULER_URL = 'https://kubernetes.default.svc.cluster.local'
+SCHEDULER_URL = "https://{}:{}".format(
+    os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default.svc.cluster.local'),
+    os.environ.get('KUBERNETES_SERVICE_PORT', '443'))
 
 # platform domain must be provided
 DEIS_DOMAIN = '{{ getv "/deis/platform/domain" }}'


### PR DESCRIPTION
Accessing the k8s api by hostname fails sometimes from within the deis/workflow pod. This changes the `requests.Session` to use the IP address and port, which is more reliable, but at least for now requires disabling verification of the local SSL cert.

Cert verification is `False` here since the IP address in the request does match any of the hostnames in the server's cert, and neither that verification nor the HTTP `Host` header can be overridden in this case in the python requests library. That is, I couldn't see any way short of monkeypatching, after reading the requests source code and overriding several classes involved.
