### PR TITLE
Controller healthcheck

### DIFF
--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: deis-workflow
+  namespace: deis
   labels:
     heritage: deis
 spec:
@@ -16,9 +17,20 @@ spec:
       containers:
         - name: deis-workflow
           image: quay.io/deisci/workflow:v2-alpha
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          imagePullPolicy: Always
           env:
             - name: DEBUG
               value: "true"
+            - name: DEIS_DATABASE_USER
+              value: deis
+            - name: DEIS_DATABASE_PASSWORD
+              value: changeme123
           ports:
             - containerPort: 8000
               name: http

--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -60,6 +60,7 @@ from .test_certificate import *  # noqa
 from .test_config import *  # noqa
 from .test_container import *  # noqa
 from .test_domain import *  # noqa
+from .test_healthcheck import *  # noqa
 from .test_hooks import *  # noqa
 from .test_key import *  # noqa
 from .test_limits import *  # noqa

--- a/rootfs/api/tests/test_healthcheck.py
+++ b/rootfs/api/tests/test_healthcheck.py
@@ -1,0 +1,24 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+
+class HealthCheckTest(TestCase):
+
+    def setUp(self):
+        self.url = '/health-check'
+
+    def test_healthcheck(self):
+        # GET and HEAD (no auth required)
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, "OK")
+
+        resp = self.client.head(self.url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_healthcheck_invalid(self):
+        for method in ('put', 'post', 'patch', 'delete'):
+            resp = getattr(self.client, method)(self.url)
+            # method not allowed
+            self.assertEqual(resp.status_code, 405)

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -4,9 +4,11 @@ RESTful view classes for presenting Deis API objects.
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from guardian.shortcuts import assign_perm, get_objects_for_user, \
     get_users_with_perms, remove_perm
+from django.views.generic import View
 from rest_framework import mixins, renderers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
@@ -17,6 +19,16 @@ from rest_framework.authtoken.models import Token
 from api import authentication, models, permissions, serializers, viewsets
 
 import requests
+
+
+class HealthCheckView(View):
+    """Simple health check view to determine if the server
+       is responding to HTTP requests.
+    """
+
+    def get(self, request):
+        return HttpResponse("OK")
+    head = get
 
 
 class UserRegistrationViewSet(GenericViewSet,

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
+from api.views import HealthCheckView
 
 
 admin.autodiscover()
@@ -17,6 +18,7 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
+    url(r'^health-check$', HealthCheckView.as_view()),
     url(r'^v2/', include('api.urls')),
 )
 


### PR DESCRIPTION
Rebases deis/deis#4457--thanks again @benwilber! Adds a matching Kubernetes [liveness probe](http://kubernetes.io/v1.1/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks) to the ReplicationController manifest.