### PR TITLE
fix(tests): exclude /usr/local/lib from converge report

### DIFF
--- a/rootfs/.coveragerc
+++ b/rootfs/.coveragerc
@@ -12,6 +12,7 @@ omit =
     # osx library files when not running in virtualenv
     /Library/*
     /System/*
+    /usr/local/lib/*
 
 [report]
 ignore_errors = True


### PR DESCRIPTION
Keep getting massive converge check on my `/usr/local/lib` global python pip install