### PR TITLE
fix(tests): make tests show CRITICAL errors

### DIFF
--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -37,7 +37,7 @@ class SilentDjangoTestSuiteRunner(DjangoTestSuiteRunner):
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         """Run tests with all but critical log messages disabled."""
         # hide any log messages less than critical
-        logging.disable(logging.CRITICAL)
+        logging.disable(logging.ERROR)
         return super(SilentDjangoTestSuiteRunner, self).run_tests(
             test_labels, extra_tests, **kwargs)
 


### PR DESCRIPTION
logging.disable() refers to the maximum logging level you should *not* see. The current code hides even Critical
https://docs.python.org/2/library/logging.html#logging.disable