### PR TITLE
ref(models): add domains to k8s data for router to use

### DIFF
--- a/rootfs/api/tests/test_utils.py
+++ b/rootfs/api/tests/test_utils.py
@@ -1,0 +1,78 @@
+import unittest
+from api import utils
+
+
+class TestUtils(unittest.TestCase):
+    """Test utils functions"""
+
+    def test_dict_merge_simple(self):
+        a = {'key': 'value'}
+        b = {'key': 'value'}
+
+        c = utils.dict_merge(a, b)
+        assert c == {'key': 'value'}
+
+        a = {'key': 'value'}
+        b = {'key2': 'value'}
+
+        c = utils.dict_merge(a, b)
+        assert c == {'key': 'value', 'key2': 'value'}
+
+    def test_dict_merge_deeper(self):
+        a = {'key': 'value', 'here': {'without': 'you'}}
+        b = {'this': 'that', 'here': {'with': 'me'}, 'other': {'magic', 'unicorn'}}
+
+        c = utils.dict_merge(a, b)
+        assert c == {
+            'key': 'value',
+            'this': 'that',
+            'here': {
+                'with': 'me',
+                'without': 'you'
+            },
+            'other': {'magic', 'unicorn'}
+        }
+
+    def test_dict_merge_even_deeper(self):
+        a = {
+            'key': 'value',
+            'here': {'without': 'you'},
+            'other': {'scrubs': {'char3': 'Cox'}}
+
+        }
+
+        b = {
+            'this': 'that',
+            'here': {'with': 'me'},
+            'other': {'magic': 'unicorn', 'scrubs': {'char1': 'JD', 'char2': 'Turk'}}
+        }
+
+        c = utils.dict_merge(a, b)
+        assert c == {
+            'key': 'value',
+            'this': 'that',
+            'here': {'with': 'me', 'without': 'you'},
+            'other': {
+                'magic': 'unicorn',
+                'scrubs': {
+                    'char1': 'JD',
+                    'char2': 'Turk',
+                    'char3': 'Cox'
+                }
+            }
+        }
+
+    def test_dict_merge_with_list(self):
+        a = {'key': 'value', 'names': ['bob', 'kyle', 'kenny', 'jimbo']}
+        b = {'key': 'value', 'names': ['kenny', 'cartman', 'stan']}
+
+        c = utils.dict_merge(a, b)
+        assert c == {'key': 'value', 'names': ['bob', 'kyle', 'kenny', 'jimbo', 'cartman', 'stan']}
+
+    def test_dict_merge_bad_merge(self):
+        """Returns b because it isn't a dict"""
+        a = {'key': 'value'}
+        b = 'duh'
+
+        c = utils.dict_merge(a, b)
+        assert c == b

--- a/rootfs/api/utils.py
+++ b/rootfs/api/utils.py
@@ -1,9 +1,11 @@
 """
 Helper functions used by the Deis server.
 """
+from __future__ import unicode_literals
 import base64
 import hashlib
 import random
+from copy import deepcopy
 
 
 def generate_app_name():
@@ -114,6 +116,57 @@ def encode(obj):
         return obj.encode('utf-8')
     else:
         return obj
+
+
+def dict_merge(origin, merge):
+    """
+    Recursively merges dict's. not just simple a["key"] = b["key"], if
+    both a and b have a key who's value is a dict then dict_merge is called
+    on both values and the result stored in the returned dictionary.
+    Also handles merging lists if they occur within the dict
+    """
+    if not isinstance(merge, dict):
+        return merge
+
+    result = deepcopy(origin)
+    for key, value in merge.iteritems():
+        if key in result and isinstance(result[key], dict):
+            result[key] = dict_merge(result[key], value)
+        else:
+            if isinstance(value, list):
+                if key not in result:
+                    result[key] = value
+                else:
+                    # merge lists without leaving potential duplicates
+                    # result[key] = list(set(result[key] + value))  # changes the order as well
+                    for item in value:
+                        if item in result[key]:
+                            continue
+
+                        result[key].append(item)
+            else:
+                result[key] = deepcopy(value)
+    return result
+
+
+def flatten(collection):
+    """
+    Flatten an arbitrarily deep structure of dicts, lists and tuples and
+    extract the strings at the leaves of the structures.
+    """
+    vals = []
+    if isinstance(collection, basestring):
+        vals.append(collection)
+    elif isinstance(collection, (list, tuple)):
+        for item in collection:
+            vals.extend(flatten(item))
+    elif isinstance(collection, dict):
+        vals.extend(flatten(collection.values()))
+    else:
+        raise Exception(
+            "Can't extract values from a %s" % collection.__class__
+        )
+    return vals
 
 
 if __name__ == "__main__":

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -1,4 +1,5 @@
 import json
+import requests
 
 from . import AbstractSchedulerClient
 from .states import JobState, TransitionError
@@ -52,6 +53,16 @@ class MockSchedulerClient(AbstractSchedulerClient):
                                   JobState.up,
                                   'the container must be up to stop')
         job['state'] = JobState.down
+
+    # Related to k8s services
+    def _get_service(self, namespace, name):
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = json.dumps({})
+        return resp
+
+    def _update_service(self, namespace, name, data):
+        pass
 
 
 SchedulerClient = MockSchedulerClient

--- a/rootfs/scheduler/utils.py
+++ b/rootfs/scheduler/utils.py
@@ -1,0 +1,53 @@
+from __future__ import unicode_literals
+from copy import deepcopy
+
+
+def dict_merge(origin, merge):
+    """
+    Recursively merges dict's. not just simple a["key"] = b["key"], if
+    both a and b have a key who's value is a dict then dict_merge is called
+    on both values and the result stored in the returned dictionary.
+    Also handles merging lists if they occur within the dict
+    """
+    if not isinstance(merge, dict):
+        return merge
+
+    result = deepcopy(origin)
+    for key, value in merge.iteritems():
+        if key in result and isinstance(result[key], dict):
+            result[key] = dict_merge(result[key], value)
+        else:
+            if isinstance(value, list):
+                if key not in result:
+                    result[key] = value
+                else:
+                    # merge lists without leaving potential duplicates
+                    # result[key] = list(set(result[key] + value))  # changes the order as well
+                    for item in value:
+                        if item in result[key]:
+                            continue
+
+                        result[key].append(item)
+            else:
+                result[key] = deepcopy(value)
+    return result
+
+
+def flatten(collection):
+    """
+    Flatten an arbitrarily deep structure of dicts, lists and tuples and
+    extract the strings at the leaves of the structures.
+    """
+    vals = []
+    if isinstance(collection, basestring):
+        vals.append(collection)
+    elif isinstance(collection, (list, tuple)):
+        for item in collection:
+            vals.extend(flatten(item))
+    elif isinstance(collection, dict):
+        vals.extend(flatten(collection.values()))
+    else:
+        raise Exception(
+            "Can't extract values from a %s" % collection.__class__
+        )
+    return vals


### PR DESCRIPTION
Domain information is now saved to routerConfig annotations in addition to still being in etcd. This solves part of #50
Also adds new flatten and dict_merge to both scheduler and models

The code has a little oddity in it where subdomains for app (on the platform domain) are added during scale event from 0 to 1. That will be address in #88

Also note that the Domain model reaches into what previously was consider a protected function (get / update services)

It is possible to remove the apps subdomain but during any scaling event it gets added back to the Domain model. This allows the router to treat all domains the same way