### PR TITLE
feat(*): update django from 1.7 to 1.8

### DIFF
--- a/rootfs/api/fields.py
+++ b/rootfs/api/fields.py
@@ -3,53 +3,8 @@ Deis API custom fields for representing data in Django forms.
 """
 
 from __future__ import unicode_literals
-from uuid import uuid4
-
-from django import forms
 from django.db import models
 
 
-class UuidField(models.CharField):
-    """A univerally unique ID field."""
-
-    description = __doc__
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('auto_created', True)
-        kwargs.setdefault('editable', False)
-        kwargs.setdefault('max_length', 32)
-        kwargs.setdefault('unique', True)
-        super(UuidField, self).__init__(*args, **kwargs)
-
-    def db_type(self, connection=None):
-        """Return the database column type for a UuidField."""
-        if connection and 'postgres' in connection.vendor:
-            return 'uuid'
-        else:
-            return "char({})".format(self.max_length)
-
-    def pre_save(self, model_instance, add):
-        """Initialize an empty field with a new UUID before it is saved."""
-        value = getattr(model_instance, self.get_attname(), None)
-        if not value and add:
-            uuid = str(uuid4())
-            setattr(model_instance, self.get_attname(), uuid)
-            return uuid
-        else:
-            return super(UuidField, self).pre_save(model_instance, add)
-
-    def formfield(self, **kwargs):
-        """Tell forms how to represent this UuidField."""
-        kwargs.update({
-            'form_class': forms.CharField,
-            'max_length': self.max_length,
-        })
-        return super(UuidField, self).formfield(**kwargs)
-
-
-try:
-    from south.modelsinspector import add_introspection_rules
-    # Tell the South schema migration tool to handle our custom fields.
-    add_introspection_rules([], [r'^api\.fields\.UuidField'])
-except ImportError:  # pragma: no cover
+class UuidField(models.UUIDField):
     pass

--- a/rootfs/api/migrations/0002_auto_20151215_0352.py
+++ b/rootfs/api/migrations/0002_auto_20151215_0352.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import api.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='app',
+            name='id',
+            field=models.SlugField(max_length=24, unique=True, null=True, validators=[api.models.validate_id_is_docker_compatible, api.models.validate_reserved_names]),
+        ),
+        migrations.AlterField(
+            model_name='app',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='build',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='config',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='container',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='key',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='push',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+        migrations.AlterField(
+            model_name='release',
+            name='uuid',
+            field=models.UUIDField(serialize=False, verbose_name='UUID', primary_key=True),
+        ),
+    ]

--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -1,37 +1,11 @@
-
 from __future__ import unicode_literals
 import logging
 
-from django.test.client import RequestFactory, Client
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 import requests
 
 
-# add patch support to built-in django test client
-
-def construct_patch(self, path, data='',
-                    content_type='application/octet-stream', **extra):
-    """Construct a PATCH request."""
-    return self.generic('PATCH', path, data, content_type, **extra)
-
-
-def send_patch(self, path, data='', content_type='application/octet-stream',
-               follow=False, **extra):
-    """Send a resource to the server using PATCH."""
-    # FIXME: figure out why we need to reimport Client (otherwise NoneType)
-    from django.test.client import Client  # @Reimport
-    response = super(Client, self).patch(
-        path, data=data, content_type=content_type, **extra)
-    if follow:
-        response = self._handle_redirects(response, **extra)
-    return response
-
-
-RequestFactory.patch = construct_patch
-Client.patch = send_patch
-
-
-class SilentDjangoTestSuiteRunner(DjangoTestSuiteRunner):
+class SilentDjangoTestSuiteRunner(DiscoverRunner):
     """Prevents api log messages from cluttering the console during tests."""
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -79,7 +79,7 @@ class AppTest(TestCase):
         response = self.client.post('/v2/apps', json.dumps(body),
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertContains(response, 'This field must be unique.', status_code=400)
+        self.assertContains(response, 'App with this id already exists.', status_code=400)
         return response
 
     @mock.patch('requests.get')

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -48,7 +48,7 @@ class BuildTest(TransactionTestCase):
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
-        build_id = response.data['uuid']
+        build_id = str(response.data['uuid'])
         build1 = response.data
         self.assertEqual(response.data['image'], body['image'])
         # read the build
@@ -203,7 +203,7 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(response.status_code, 201)
         build = Build.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(build), "{}-{}".format(
-                         response.data['app'], response.data['uuid'][:7]))
+                         response.data['app'], str(response.data['uuid'])[:7]))
 
     @mock.patch('requests.post', mock_status_ok)
     def test_admin_can_create_builds_on_other_apps(self):
@@ -225,7 +225,7 @@ class BuildTest(TransactionTestCase):
         self.assertEqual(response.status_code, 201)
         build = Build.objects.get(uuid=response.data['uuid'])
         self.assertEqual(str(build), "{}-{}".format(
-                         response.data['app'], response.data['uuid'][:7]))
+                         response.data['app'], str(response.data['uuid'])[:7]))
 
     @mock.patch('requests.post', mock_status_ok)
     def test_unauthorized_user_cannot_modify_build(self):

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -250,7 +250,7 @@ class ConfigTest(TransactionTestCase):
         """Test the text representation of a node."""
         config5 = self.test_config()
         config = Config.objects.get(uuid=config5['uuid'])
-        self.assertEqual(str(config), "{}-{}".format(config5['app'], config5['uuid'][:7]))
+        self.assertEqual(str(config), "{}-{}".format(config5['app'], str(config5['uuid'])[:7]))
 
     @mock.patch('requests.post', mock_status_ok)
     def test_valid_config_keys(self):

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -166,10 +166,9 @@ class HookTest(TransactionTestCase):
         build = {'username': 'autotest', 'app': app_id}
         url = '/v2/hooks/builds'.format(**locals())
         SHA = 'ecdff91c57a0b9ab82e89634df87e293d259a3aa'
-        DOCKERFILE = """
-        FROM busybox
-        CMD /bin/true
-        """
+        DOCKERFILE = """FROM busybox
+        CMD /bin/true"""
+
         body = {'receive_user': 'autotest',
                 'receive_repo': app_id,
                 'image': '{app_id}:v2'.format(**locals()),

--- a/rootfs/api/urls.py
+++ b/rootfs/api/urls.py
@@ -5,16 +5,16 @@ URL routing patterns for the Deis REST API.
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from api import routers, views
+from rest_framework.authtoken.views import obtain_auth_token as views_obtain_auth_token
 
 
 router = routers.ApiRouter()
 
 # Add the generated REST URLs and login/logout endpoint
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^', include(router.urls)),
     # application release components
     url(r"^apps/(?P<id>{})/config/?".format(settings.APP_URL_REGEX),
@@ -86,7 +86,7 @@ urlpatterns = patterns(
     url(r'^auth/passwd/?',
         views.UserManagementViewSet.as_view({'post': 'passwd'})),
     url(r'^auth/login/',
-        'rest_framework.authtoken.views.obtain_auth_token'),
+        views_obtain_auth_token),
     url(r'^auth/tokens/',
         views.TokenManagementViewSet.as_view({'post': 'regenerate'})),
     # admin sharing
@@ -100,4 +100,4 @@ urlpatterns = patterns(
         views.CertificateViewSet.as_view({'get': 'list', 'post': 'create'})),
     # list users
     url(r'^users/', views.UserView.as_view({'get': 'list'})),
-)
+]

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -190,9 +190,11 @@ class AppViewSet(BaseDeisViewSet):
         instance = self.filter_queryset(queryset)
         page = self.paginate_queryset(instance)
         if page is not None:
-            serializer = self.get_pagination_serializer(page)
-        else:
-            serializer = self.get_serializer(instance, many=True)
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(instance, many=True)
+
         return Response(serializer.data)
 
     def post_save(self, app):

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -9,6 +9,10 @@ set -eo pipefail
 # set debug based on envvar
 [[ $DEBUG ]] && set -x
 
+echo system information:
+echo "Django Version: $(./manage.py --version)"
+python --version
+
 # configure etcd
 export ETCD_PORT=${DEIS_ETCD_1_SERVICE_PORT_CLIENT:-4001}
 export ETCD_HOST=${DEIS_ETCD_1_SERVICE_HOST:-$HOST}

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -13,7 +13,6 @@ import tempfile
 PROJECT_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 
 DEBUG = False
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -83,23 +82,29 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.request",
-    "django.core.context_processors.static",
-    "django.core.context_processors.tz",
-    "django.contrib.messages.context_processors.messages",
-    "deis.context_processors.site",
-)
+# Manage templates
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            # insert your TEMPLATE_DIRS here
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.request",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "deis.context_processors.site"
+            ],
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'corsheaders.middleware.CorsMiddleware',
@@ -165,8 +170,7 @@ CORS_EXPOSE_HEADERS = (
 )
 
 REST_FRAMEWORK = {
-    'DEFAULT_MODEL_SERIALIZER_CLASS':
-    'rest_framework.serializers.ModelSerializer',
+    'DEFAULT_MODEL_SERIALIZER_CLASS': 'rest_framework.serializers.ModelSerializer',
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
@@ -176,8 +180,8 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
-    'PAGINATE_BY': 100,
-    'PAGINATE_BY_PARAM': 'page_size',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -7,11 +7,10 @@ installed apps.
 
 from __future__ import unicode_literals
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from api.views import HealthCheckView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^health-check$', HealthCheckView.as_view()),
     url(r'^v2/', include('api.urls')),
-)
+]

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,14 +1,12 @@
 # Deis controller requirements
 #
-Django==1.7.11
-django-cors-headers==1.0.0
-# required for south migrations
-django-fsm==2.2.0
-django-guardian==1.2.5
+Django==1.8.7
+django-cors-headers==1.1.0
+django-guardian==1.3.2
+djangorestframework==3.3.2
 jsonfield==1.0.3
-djangorestframework==3.0.5
 docker-py==1.6.0
-gunicorn==19.3.0
+gunicorn==19.4.1
 psycopg2==2.6.1
 python-etcd==0.3.2
 PyYAML==3.11

--- a/rootfs/setup.cfg
+++ b/rootfs/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 99
-exclude = api/migrations,api/south_migrations,templates,venv
+exclude = api/migrations,templates,venv
 max-complexity = 12


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/releases/1.8/

Notable changes:
* Moved us to using the official `UUIDField` - The oddity with this one is the returned value is a `UUID` object so it need to be based to string if any `substring` or similar operation is performed
* Updated all libraries
* TestCase http client seems to be returning values differently than it used to. `OrderedDict` straight up without `results` or `count` on the top level
* templating changed in 1.8 to support multiple engines. https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/ on how it all changed
* django.conf.urls.patterns is deprecated in 1.8 and removed in 1.10 https://docs.djangoproject.com/en/dev/releases/1.8/#django-conf-urls-patterns

Note: `django_auth_ldap` is disabled since it causes a migration issues I haven't been able to debug