### PR TITLE
feat(*): update django from 1.8 to 1.9

### DIFF
--- a/rootfs/deis/context_processors.py
+++ b/rootfs/deis/context_processors.py
@@ -1,9 +1,0 @@
-
-from django.contrib.sites.models import get_current_site
-from django.utils.functional import SimpleLazyObject
-
-
-def site(request):
-    return {
-        'site': SimpleLazyObject(lambda: get_current_site(request)),
-    }

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -99,8 +99,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.template.context_processors.static",
                 "django.template.context_processors.tz",
-                "django.contrib.messages.context_processors.messages",
-                "deis.context_processors.site"
+                "django.contrib.messages.context_processors.messages"
             ],
         },
     },
@@ -112,6 +111,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'api.middleware.APIVersionMiddleware',
     'deis.middleware.PlatformVersionMiddleware',
     # Uncomment the next line for simple clickjacking protection:
@@ -140,8 +140,7 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'corsheaders',
     # Deis apps
-    'api',
-    'registry',
+    'api'
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -313,7 +312,7 @@ REGISTRATION_ENABLED = True
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': os.environ.get('DEIS_DATABASE_NAME', 'deis'),
         'USER': os.environ.get('DEIS_DATABASE_USER', ''),
         'PASSWORD': os.environ.get('DEIS_DATABASE_PASSWORD', ''),

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,6 +1,6 @@
 # Deis controller requirements
 #
-Django==1.8.7
+Django==1.9
 django-cors-headers==1.1.0
 django-guardian==1.3.2
 djangorestframework==3.3.2


### PR DESCRIPTION

Notable changes:
* ditch deis context_processor for https://docs.djangoproject.com/en/1.9/ref/contrib/sites/#site-middleware
* `registry` no longer treated as an app as it was causing AppRegistry prepared problems
* django-json-field swapped out for jsonfield for django 1.9 compatibility