### PR TITLE
feat(*): use latest python (3.5 right now) for API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb"
   - sudo dpkg -i shellcheck_0.3.7-5_amd64.deb
   - sudo pip install virtualenv
-  - virtualenv $HOME/venv
+  - virtualenv -p python3.5 $HOME/venv
   - source $HOME/venv/bin/activate
   - createdb -U postgres deis
 install:

--- a/rootfs/api/admin.py
+++ b/rootfs/api/admin.py
@@ -4,7 +4,6 @@
 Django admin app configuration for Deis API models.
 """
 
-from __future__ import unicode_literals
 
 from django.contrib import admin
 from guardian.admin import GuardedModelAdmin

--- a/rootfs/api/fields.py
+++ b/rootfs/api/fields.py
@@ -2,7 +2,6 @@
 Deis API custom fields for representing data in Django forms.
 """
 
-from __future__ import unicode_literals
 from django.db import models
 
 

--- a/rootfs/api/management/commands/load_db_state_to_etcd.py
+++ b/rootfs/api/management/commands/load_db_state_to_etcd.py
@@ -9,8 +9,8 @@ class Command(BaseCommand):
     """
     def handle(self, *args, **options):
         """Publishes Deis platform state from the database to etcd."""
-        print "Publishing DB state to etcd..."
+        print("Publishing DB state to etcd...")
         for model in (Key, App, Domain, Certificate, Config):
             for obj in model.objects.all():
                 obj.save()
-        print "Done Publishing DB state to etcd."
+        print("Done Publishing DB state to etcd.")

--- a/rootfs/api/migrations/0001_initial.py
+++ b/rootfs/api/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 from django.db import models, migrations
 import jsonfield.fields

--- a/rootfs/api/migrations/0002_auto_20151215_0352.py
+++ b/rootfs/api/migrations/0002_auto_20151215_0352.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 from django.db import migrations, models
 import api.models

--- a/rootfs/api/routers.py
+++ b/rootfs/api/routers.py
@@ -2,7 +2,6 @@
 REST framework URL routing classes.
 """
 
-from __future__ import unicode_literals
 
 from rest_framework.routers import DefaultRouter
 from rest_framework.routers import Route

--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -2,7 +2,6 @@
 Classes to serialize the RESTful representation of Deis API models.
 """
 
-from __future__ import unicode_literals
 import json
 import re
 
@@ -35,7 +34,7 @@ class JSONFieldSerializer(serializers.JSONField):
 
     def to_representation(self, obj):
         """Serialize the field's JSON data, for read operations."""
-        for k, v in obj.viewitems():
+        for k, v in obj.items():
             if v is None:  # NoneType is used to unset a value
                 continue
 
@@ -143,64 +142,64 @@ class ConfigSerializer(serializers.ModelSerializer):
         """Metadata options for a :class:`ConfigSerializer`."""
         model = models.Config
 
-    def validate_values(self, value):
-        for k, v in value.viewitems():
-            if not re.match(CONFIGKEY_MATCH, k):
+    def validate_values(self, data):
+        for key, value in data.items():
+            if not re.match(CONFIGKEY_MATCH, key):
                 raise serializers.ValidationError(
                     "Config keys must start with a letter or underscore and "
                     "only contain [A-z0-9_]")
 
-        return value
+        return data
 
-    def validate_memory(self, value):
-        for k, v in value.viewitems():
-            if v is None:  # use NoneType to unset a value
+    def validate_memory(self, data):
+        for key, value in data.items():
+            if value is None:  # use NoneType to unset an item
                 continue
 
-            if not re.match(PROCTYPE_MATCH, k):
+            if not re.match(PROCTYPE_MATCH, key):
                 raise serializers.ValidationError("Process types can only contain [a-z]")
 
-            if not re.match(MEMLIMIT_MATCH, str(v)):
+            if not re.match(MEMLIMIT_MATCH, str(value)):
                 raise serializers.ValidationError(
                     "Limit format: <number><unit>, where unit = B, K, M or G")
 
-        return value
+        return data
 
-    def validate_cpu(self, value):
-        for k, v in value.viewitems():
-            if v is None:  # use NoneType to unset a value
+    def validate_cpu(self, data):
+        for key, value in data.items():
+            if value is None:  # use NoneType to unset an item
                 continue
 
-            if not re.match(PROCTYPE_MATCH, k):
+            if not re.match(PROCTYPE_MATCH, key):
                 raise serializers.ValidationError("Process types can only contain [a-z]")
 
-            shares = re.match(CPUSHARE_MATCH, str(v))
+            shares = re.match(CPUSHARE_MATCH, str(value))
             if not shares:
                 raise serializers.ValidationError("CPU shares must be an integer")
 
-            for v in shares.groupdict().viewvalues():
+            for share in shares.groupdict().values():
                 try:
-                    i = int(v)
+                    i = int(share)
                 except ValueError:
                     raise serializers.ValidationError("CPU shares must be an integer")
 
                 if i > 1024 or i < 0:
                     raise serializers.ValidationError("CPU shares must be between 0 and 1024")
 
-        return value
+        return data
 
-    def validate_tags(self, value):
-        for k, v in value.viewitems():
-            if v is None:  # use NoneType to unset a value
+    def validate_tags(self, data):
+        for key, value in data.items():
+            if value is None:  # use NoneType to unset an item
                 continue
 
-            if not re.match(TAGKEY_MATCH, k):
+            if not re.match(TAGKEY_MATCH, key):
                 raise serializers.ValidationError("Tag keys can only contain [a-z]")
 
-            if not re.match(TAGVAL_MATCH, str(v)):
-                raise serializers.ValidationError("Invalid tag value")
+            if not re.match(TAGVAL_MATCH, str(value)):
+                raise serializers.ValidationError("Invalid tag data")
 
-        return value
+        return data
 
 
 class ReleaseSerializer(serializers.ModelSerializer):

--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import logging
 
 from django.test.runner import DiscoverRunner

--- a/rootfs/api/tests/test_api_middleware.py
+++ b/rootfs/api/tests/test_api_middleware.py
@@ -3,7 +3,6 @@ Unit tests for the Deis api app.
 
 Run the tests with "./manage.py test api"
 """
-from __future__ import unicode_literals
 
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -4,11 +4,10 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 import logging
-import mock
+from unittest import mock
 import requests
 
 from django.contrib.auth.models import User
@@ -155,12 +154,12 @@ class AppTest(TestCase):
         url = '/v2/apps/{app_id}'.format(**locals())
         response = self.client.delete(url,
                                       HTTP_AUTHORIZATION='token {}'.format(self.token))
-        self.assertEquals(response.status_code, 204)
+        self.assertEqual(response.status_code, 204)
         for endpoint in ('containers', 'config', 'releases', 'builds'):
             url = '/v2/apps/{app_id}/{endpoint}'.format(**locals())
             response = self.client.get(url,
                                        HTTP_AUTHORIZATION='token {}'.format(self.token))
-            self.assertEquals(response.status_code, 404)
+            self.assertEqual(response.status_code, 404)
 
     def test_app_reserved_names(self):
         """Nobody should be able to create applications with names which are reserved."""

--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -4,10 +4,9 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
-import urllib
+from urllib.parse import urlencode
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -66,7 +65,7 @@ class AuthTest(TestCase):
         self.assertDictContainsSubset(expected, response.data)
         # test login
         url = '/v2/auth/login/'
-        payload = urllib.urlencode({'username': username, 'password': password})
+        payload = urlencode({'username': username, 'password': password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 200)
@@ -142,7 +141,7 @@ class AuthTest(TestCase):
         self.assertDictContainsSubset(expected, response.data)
         # test login
         url = '/v2/auth/login/'
-        payload = urllib.urlencode({'username': username, 'password': password})
+        payload = urlencode({'username': username, 'password': password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 200)
@@ -163,7 +162,7 @@ class AuthTest(TestCase):
 
         try:
             self.client.post(url, json.dumps(submit), content_type='application/json')
-        except Exception, e:
+        except Exception as e:
             self.assertEqual(str(e), 'not_a_mode is not a valid registation mode')
 
     def test_cancel(self):
@@ -260,12 +259,12 @@ class AuthTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # test login with old password
         url = '/v2/auth/login/'
-        payload = urllib.urlencode({'username': username, 'password': password})
+        payload = urlencode({'username': username, 'password': password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 400)
         # test login with new password
-        payload = urllib.urlencode({'username': username, 'password': 'password2'})
+        payload = urlencode({'username': username, 'password': 'password2'})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 200)
@@ -287,12 +286,12 @@ class AuthTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # test login with old password
         url = '/v2/auth/login/'
-        payload = urllib.urlencode({'username': self.user1.username, 'password': old_password})
+        payload = urlencode({'username': self.user1.username, 'password': old_password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 400)
         # test login with new password
-        payload = urllib.urlencode({'username': self.user1.username, 'password': new_password})
+        payload = urlencode({'username': self.user1.username, 'password': new_password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 200)
@@ -308,7 +307,7 @@ class AuthTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # test login with new password
         url = '/v2/auth/login/'
-        payload = urllib.urlencode({'username': self.user1.username, 'password': old_password})
+        payload = urlencode({'username': self.user1.username, 'password': old_password})
         response = self.client.post(url, data=payload,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 200)

--- a/rootfs/api/tests/test_build.py
+++ b/rootfs/api/tests/test_build.py
@@ -4,13 +4,12 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-import mock
+from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Build
@@ -89,6 +88,7 @@ class BuildTest(TransactionTestCase):
         body = {'image': 'autotest/example'}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
+
         for key in response.data:
             self.assertIn(key, ['uuid', 'owner', 'created', 'updated', 'app', 'dockerfile',
                                 'image', 'procfile', 'sha'])

--- a/rootfs/api/tests/test_certificate.py
+++ b/rootfs/api/tests/test_certificate.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 
 import json
 
@@ -106,7 +105,7 @@ thejiQz0ThCMBw7QMpVOiSvYAlQG0ATsRYwdTDqENIWKlerOLCSuxmbqe8XeDKhq
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         expected = {'common_name': 'autotest.example.com',
                     'expires': '2016-03-05T17:14:27UTC'}
-        for key, value in expected.items():
+        for key, value in list(expected.items()):
             self.assertEqual(response.data[key], value)
 
     def test_certficate_denied_requests(self):

--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -5,14 +5,13 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 import requests
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-import mock
+from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Config

--- a/rootfs/api/tests/test_container.py
+++ b/rootfs/api/tests/test_container.py
@@ -4,13 +4,12 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-import mock
+from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import App, Build, Container, Release

--- a/rootfs/api/tests/test_domain.py
+++ b/rootfs/api/tests/test_domain.py
@@ -4,7 +4,6 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 

--- a/rootfs/api/tests/test_healthcheck.py
+++ b/rootfs/api/tests/test_healthcheck.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 
 from django.test import TestCase
 
@@ -11,8 +10,7 @@ class HealthCheckTest(TestCase):
     def test_healthcheck(self):
         # GET and HEAD (no auth required)
         resp = self.client.get(self.url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, "OK")
+        self.assertContains(resp, "OK", status_code=200)
 
         resp = self.client.head(self.url)
         self.assertEqual(resp.status_code, 200)

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -4,14 +4,13 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-import mock
+from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from . import mock_status_ok

--- a/rootfs/api/tests/test_key.py
+++ b/rootfs/api/tests/test_key.py
@@ -5,7 +5,6 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 
@@ -151,7 +150,7 @@ class KeyTest(TestCase):
 
     def test_rsa_key_fingerprint(self):
         fp = fingerprint(RSA_PUBKEY)
-        self.assertEquals(fp, '54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:f5')
+        self.assertEqual(fp, '54:6d:da:1f:91:b5:2b:6f:a2:83:90:c4:f9:73:76:f5')
 
     def test_key_api_with_non_superuser_rsa(self):
         self.user = User.objects.get(username='autotest2')

--- a/rootfs/api/tests/test_perm.py
+++ b/rootfs/api/tests/test_perm.py
@@ -1,5 +1,4 @@
 
-from __future__ import unicode_literals
 import json
 
 from django.contrib.auth.models import User

--- a/rootfs/api/tests/test_release.py
+++ b/rootfs/api/tests/test_release.py
@@ -4,14 +4,13 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 import uuid
 
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-import mock
+from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from api.models import Release
@@ -59,7 +58,7 @@ class ReleaseTest(TransactionTestCase):
         release1 = response.data
         self.assertIn('config', response.data)
         self.assertIn('build', response.data)
-        self.assertEquals(release1['version'], 1)
+        self.assertEqual(release1['version'], 1)
         # check to see that a new release was created
         url = '/v2/apps/{app_id}/releases/v2'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -68,7 +67,7 @@ class ReleaseTest(TransactionTestCase):
         self.assertNotEqual(release1['uuid'], release2['uuid'])
         self.assertNotEqual(release1['config'], release2['config'])
         self.assertEqual(release1['build'], release2['build'])
-        self.assertEquals(release2['version'], 2)
+        self.assertEqual(release2['version'], 2)
         # check that updating the build rolls a new release
         url = '/v2/apps/{app_id}/builds'.format(**locals())
         build_config = json.dumps({'PATH': 'bin:/usr/local/bin:/usr/bin:/bin'})
@@ -85,7 +84,7 @@ class ReleaseTest(TransactionTestCase):
         release3 = response.data
         self.assertNotEqual(release2['uuid'], release3['uuid'])
         self.assertNotEqual(release2['build'], release3['build'])
-        self.assertEquals(release3['version'], 3)
+        self.assertEqual(release3['version'], 3)
         # check that we can fetch a previous release
         url = '/v2/apps/{app_id}/releases/v2'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -93,7 +92,7 @@ class ReleaseTest(TransactionTestCase):
         release2 = response.data
         self.assertNotEqual(release2['uuid'], release3['uuid'])
         self.assertNotEqual(release2['build'], release3['build'])
-        self.assertEquals(release2['version'], 2)
+        self.assertEqual(release2['version'], 2)
         # disallow post/put/patch/delete
         url = '/v2/apps/{app_id}/releases'.format(**locals())
         response = self.client.post(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -175,13 +174,13 @@ class ReleaseTest(TransactionTestCase):
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         release1 = response.data
-        self.assertEquals(release1['version'], 1)
+        self.assertEqual(release1['version'], 1)
         url = '/v2/apps/{app_id}/releases/v3'.format(**locals())
         response = self.client.get(url, content_type='application/json',
                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         release3 = response.data
-        self.assertEquals(release3['version'], 3)
+        self.assertEqual(release3['version'], 3)
         self.assertNotEqual(release1['uuid'], release3['uuid'])
         self.assertEqual(release1['build'], release3['build'])
         self.assertEqual(release1['config'], release3['config'])

--- a/rootfs/api/tests/test_scheduler.py
+++ b/rootfs/api/tests/test_scheduler.py
@@ -4,14 +4,13 @@ Unit tests for the Deis api app.
 Run the tests with "./manage.py test api"
 """
 
-from __future__ import unicode_literals
 
 import json
 
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TransactionTestCase
-import mock
+from unittest import mock
 from rest_framework.authtoken.models import Token
 
 from scheduler import chaos
@@ -228,7 +227,7 @@ class SchedulerTest(TransactionTestCase):
         self.assertEqual(states, set(['error']))
         # make sure we can cleanup after enough tries
         containers = 20
-        for _ in xrange(100):
+        for _ in range(100):
             url = "/v2/apps/{app_id}/scale".format(**locals())
             body = {'web': 0}
             response = self.client.post(url, json.dumps(body), content_type='application/json',

--- a/rootfs/api/tests/test_users.py
+++ b/rootfs/api/tests/test_users.py
@@ -1,5 +1,4 @@
 
-from __future__ import unicode_literals
 
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/rootfs/api/urls.py
+++ b/rootfs/api/urls.py
@@ -2,7 +2,6 @@
 URL routing patterns for the Deis REST API.
 """
 
-from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url

--- a/rootfs/api/utils.py
+++ b/rootfs/api/utils.py
@@ -1,7 +1,6 @@
 """
 Helper functions used by the Deis server.
 """
-from __future__ import unicode_literals
 import base64
 import hashlib
 import random
@@ -121,7 +120,7 @@ def dict_merge(origin, merge):
         return merge
 
     result = deepcopy(origin)
-    for key, value in merge.iteritems():
+    for key, value in merge.items():
         if key in result and isinstance(result[key], dict):
             result[key] = dict_merge(result[key], value)
         else:

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -204,7 +204,7 @@ class AppViewSet(BaseDeisViewSet):
         new_structure = {}
         app = self.get_object()
         try:
-            for target, count in request.data.viewitems():
+            for target, count in request.data.items():
                 new_structure[target] = int(count)
             models.validate_app_structure(new_structure)
             app.scale(request.user, new_structure)
@@ -228,7 +228,7 @@ class AppViewSet(BaseDeisViewSet):
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                             content_type='text/plain')
         except EnvironmentError as e:
-            if e.message == 'Error accessing deis-logger':
+            if str(e) == 'Error accessing deis-logger':
                 return Response("Error accessing logs for {}".format(app.id),
                                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                                 content_type='text/plain')

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -17,11 +17,15 @@ apk add --update-cache \
   libffi-dev \
   libpq \
   postgresql-dev \
-  python \
-  python-dev
+  python3 \
+  python3-dev \
+  git
+
+# Symlink python3 binary to python
+ln -s /usr/bin/python3 /usr/bin/python
 
 # install pip
-curl -sSL https://raw.githubusercontent.com/pypa/pip/7.0.3/contrib/get-pip.py | python -
+curl -sSL https://raw.githubusercontent.com/pypa/pip/7.1.2/contrib/get-pip.py | python -
 
 # add a deis user
 adduser deis -D -h /app -s /bin/bash
@@ -41,5 +45,6 @@ apk del --purge \
   curl \
   libffi-dev \
   postgresql-dev \
-  python-dev
+  python3-dev \
+  git
 rm -rf /var/cache/apk/*

--- a/rootfs/deis/__init__.py
+++ b/rootfs/deis/__init__.py
@@ -4,6 +4,4 @@ settings, and WSGI setup. Most application domain-specific code lives in
 the api, provider, cm, and web Django apps.
 """
 
-from __future__ import absolute_import
-
 __version__ = '2.0.0-dev'

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -2,7 +2,6 @@
 Django settings for the Deis project.
 """
 
-from __future__ import unicode_literals
 import os.path
 import random
 import string

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -5,7 +5,6 @@ This is the "master" urls.py which then includes the urls.py files of
 installed apps.
 """
 
-from __future__ import unicode_literals
 
 from django.conf.urls import include, url
 from api.views import HealthCheckView

--- a/rootfs/deis/wsgi.py
+++ b/rootfs/deis/wsgi.py
@@ -8,7 +8,6 @@ this application via the ``WSGI_APPLICATION`` setting.
 
 """
 
-from __future__ import unicode_literals
 import os
 
 from django.core.wsgi import get_wsgi_application

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -2,7 +2,4 @@
 coverage>=4.0
 
 # Run "make flake8" to check python syntax and style
-flake8==2.4.1
-
-# Used for mocking endpoints
-mock==1.0.1
+flake8==2.5.1

--- a/rootfs/manage.py
+++ b/rootfs/manage.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import unicode_literals
 import os
 import sys
 

--- a/rootfs/registry/__init__.py
+++ b/rootfs/registry/__init__.py
@@ -1,1 +1,1 @@
-from dockerclient import publish_release  # noqa
+from .dockerclient import publish_release  # noqa

--- a/rootfs/registry/dockerclient.py
+++ b/rootfs/registry/dockerclient.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Support the Deis workflow by manipulating and publishing Docker images."""
 
-from __future__ import unicode_literals
 import logging
 
 from django.conf import settings
@@ -84,7 +83,7 @@ def log_output(stream):
     for chunk in stream:
         logger.debug(chunk)
         # error handling requires looking at the response body
-        if '"error"' in chunk.lower():
+        if b'"error"' in chunk.lower():
             raise docker.errors.DockerException(chunk)
 
 

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -10,7 +10,8 @@ gunicorn==19.4.1
 psycopg2==2.6.1
 python-etcd==0.3.2
 PyYAML==3.11
-requests==2.8.1
-simpleflock==0.0.2
+requests==2.9.1
+#simpleflock==0.0.2
+git+https://github.com/helgi/python-simpleflock.git@python3#egg=simpleflock
 static==1.1.1
 morph==0.1.2

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -58,7 +58,7 @@ class MockSchedulerClient(AbstractSchedulerClient):
     def _get_service(self, namespace, name):
         resp = requests.Response()
         resp.status_code = 200
-        resp._content = json.dumps({})
+        resp._content = b'{}'
         return resp
 
     def _update_service(self, namespace, name, data):

--- a/rootfs/scheduler/utils.py
+++ b/rootfs/scheduler/utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from copy import deepcopy
 
 
@@ -13,7 +12,7 @@ def dict_merge(origin, merge):
         return merge
 
     result = deepcopy(origin)
-    for key, value in merge.iteritems():
+    for key, value in merge.items():
         if key in result and isinstance(result[key], dict):
             result[key] = dict_merge(result[key], value)
         else:


### PR DESCRIPTION
`from __future__ import unicode_literals` is not needed anymore, see http://python-future.org/unicode_literals.html

This piggybacks on the Django 1.9 bump.

On OSX you can `brew install python3` and then do the following

```
virtualenv -p python3 deis-py3
source deis-py3/bin/activate
python --version
pip install --upgrade -r rootfs/requirements.txt
make test
```

Note I haven't looked at what is required on the travis side of things