### PR TITLE
fix(api): delete new_release only if it exists

### DIFF
--- a/rootfs/api/models.py
+++ b/rootfs/api/models.py
@@ -738,7 +738,8 @@ class Build(UuidAuditedModel):
             self.app.deploy(user, new_release)
             return new_release
         except RuntimeError:
-            new_release.delete()
+            if 'new_release' in locals():
+                new_release.delete()
             raise
 
     def save(self, **kwargs):
@@ -895,7 +896,8 @@ class Release(UuidAuditedModel):
             self.app.deploy(user, new_release)
             return new_release
         except RuntimeError:
-            new_release.delete()
+            if 'new_release' in locals():
+                new_release.delete()
             raise
 
     def save(self, *args, **kwargs):  # noqa

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -363,7 +363,8 @@ class ReleaseViewSet(AppResourceViewSet):
         except EnvironmentError as e:
             return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except RuntimeError:
-            new_release.delete()
+            if 'new_release' in locals():
+                new_release.delete()
             raise
 
 


### PR DESCRIPTION
When debugging #95, there was a case where the `except` handler failed since `new_release` hadn't been defined yet in the preceding `try` block. This guards against that potential problem in the three similar cases I could find.