### PR TITLE
fix(_tests): add admin user check tests

### DIFF
--- a/_tests/users_test.go
+++ b/_tests/users_test.go
@@ -14,10 +14,10 @@ var _ = Describe("Users", func() {
 		It("can list all users", func() {
 			output, err := execute("deis users:list")
 			Expect(err).NotTo(HaveOccurred())
-			// TODO: search for both test and test-admin users
 			Expect(output).To(SatisfyAll(
 				HavePrefix("=== Users"),
-				ContainSubstring(testUser)))
+				ContainSubstring(testUser),
+				ContainSubstring(testAdminUser)))
 		})
 	})
 


### PR DESCRIPTION
A very minor fix to `users_test.go` that removes a TODO. Tested interactively with ginkgo's awesome [focus](https://onsi.github.io/ginkgo/#focused-specs) feature.