### PR TITLE
doc(routing/ingress): improve docs

### DIFF
--- a/docs/src/installing-deis/installing-the-deis-platform.md
+++ b/docs/src/installing-deis/installing-the-deis-platform.md
@@ -35,23 +35,119 @@ $ kubectl get pods --namespace=deis
 
 Once you see all of the pods ready, your Deis platform is running on a cluster!
 
-## Mapping a Default Domain
+## Routing Traffic
 
-Deis will route traffic from Kubernetes nodes to Deis components, but to
-do so it needs a domain. By default, Deis is configured to use the
-domain `example.com`. For basic Deis testing, simply add an entry to
-your host machine's `/etc/hosts` file.
+The Deis router component will use an incoming request's HTTP `Host`
+header to direct traffic to Deis components and to applications deployed
+via Deis. It is therefore important that the router be configured
+properly and that DNS and/or your local `/etc/hosts` file are as well.
+
+### Configuring the Platform Domain
+
+The Deis router requires a "platform domain" be set.  Deis components
+that respond to HTTP requests and applications deployed via Deis will
+all live on subdomains of the platform domain.  When installing Deis
+via helm, the platform domain is set to `example.com` by default.  This
+can be changed by editing Deis' helm chart prior to installation.
+Alternatively, the change can be made after Deis has been installed
+by editing the router's replication controller like so:
+
+```
+$ kubectl edit rc deis-router --namespace=deis
+```
+
+Find `example.com` in the manifest, change it to a domain of your
+choosing, and save changes.  Kubernetes will apply the changes and
+the router will dynamically reconfigure itself accordingly.
+
+### Getting Traffic to the Cluster
+
+With the platform domain configured, the only remaining concern
+is to ensure traffic for that domain reaches the cluster.  There
+are a few ways of doing this, and which you use may depend on the
+capabilities of your infrastructure and your Kubernetes cluster.
+
+In general, the goal is to connect traffic bound for
+`*.the-domain-you.picked` to your Kubernetes cluster.
+
+#### Using an Automatically Provisioned Load Balancer
+
+If your Kubernetes cluster and the underlying infrastructure
+support it, the Deis router's service (which is of `type:
+LoadBalancer`) will automatically provision an "external"
+(external to the Kubernetes cluster) load balancer.  On AWS,
+for instance, this takes the form of an ELB, while on Google
+Container Engine, it takes the form of a routing rule.
+
+If it is supported, you will be able to find the DNS name or
+IP(s) of the external load balancer like so:
+
+```
+$ kubectl describe service deis-router --namespace=deis
+```
+
+Examine the `LoadBalancer Ingress` field to find the DNS
+name or IP(s).  The former can be added to DNS as a CNAME,
+while the latter can be added as an A record.
+
+#### Creating Your Own Load Balancer
+
+On Kubernetes clusters and underlying infrastructure that
+do not support the automated provisioning of an external
+load balancer for the Deis router, you may provision your
+own and add _all_ minion nodes of the Kubernetes cluster to
+the pool.
+
+The load balancer must pass incoming traffic on the
+following ports to the _same_ ports on the Kubernetes
+worker nodes:
+
+* 80
+* 443
+* 2222
+* 9090
+
+The Deis router component listens to those ports on any
+host it runs on.  Since not _all_ nodes are likely to
+be running the router, a health check should be used to
+determine which node(s) can serve requests.  The router's
+healthcheck should use the HTTP protocol, port `9090`, and
+the request path `/healthz`.
+
+Load balancer idle timeouts should be set to at least `1200`
+seconds so connections do not close prematurely during longer
+running requests such as application deployments.
+
+#### Without a Load Balancer
+
+On some platforms (Vagrant, for instance) a load balancer is
+not an easy or practical thing to provision.  In these cases,
+one can directly identify the public IP of a Kubernetes node
+that is hosting a router pod and use that information to
+configure DNS or the local `/etc/hosts` file.
 
 You can find the IP address of a node using `kubectl`:
 
 ```
-$ kubectl get nodes
-NAME         LABELS                              STATUS    AGE
-10.245.1.3   kubernetes.io/hostname=10.245.1.3   Ready     19h
+$ kubectl get pods --namespace=deis | grep deis-router
+deis-router-ih25q           1/1       Running   0          2h
 ```
 
-You may have numerous entries. All entries should be able to route to
-Deis, though.
+Using the pod name determined through the above, one can
+use `kubectl` to determine what node the pod is running on:
+
+```
+$ kubectl describe pod describe pod deis-router-ih25q --namespace=deis
+```
+
+The `Node` field of the response should provide an IP:
+
+```
+Node:				10.245.1.3/
+```
+
+If the IP is public, this can be used to configure DNS or the
+local `/etc/hosts` file.
 
 In your `/etc/hosts` file, add an entry like this:
 
@@ -62,51 +158,32 @@ In your `/etc/hosts` file, add an entry like this:
 This route will get you started, though you may find that you have to
 manually maintain this file.
 
-### Using a DNS Service
+#### Using a DNS Service
 
-Rather than hard-coding a hostfile entry, you may prefer to [configure a DNS][]
-record. `xip.io` is a particularly easy way to do this.
+With any of the avenues described above, some hassle may be spared by
+leveraging a service such as `xip.io`, which will not require any
+editing of DNS records or local `/etc/hosts` files.
 
-Edit `$(helm home)/workspace/charts/deis/manifests/deis-router-rc.yaml`
-and change the `domain` annotation to point to your DNS entry:
+Simply determine the correct IP to route your traffic to (as described
+above), then configure the router's platform domain to be `<ip>.xip.io`
 
-```yaml
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: deis-router
-  namespace: deis
-  labels:
-    heritage: deis
-  annotations:
-    deis.io/routerConfig: |
-      {
-        "domain": "10.245.1.3.xip.io",
-        "useProxyProtocol": false
-      }
-spec:
-  replicas: 1
-  selector:
-    app: deis-router
-#...
-```
+### Testing
 
-Once you have changed and saved the file, run `kubectl apply`:
+To test that traffic reaches its intended destination, a request can be
+sent to the Deis controller like so:
 
 ```
-$ kubectl --namespace=deis apply -f $(helm home)/workspace/charts/deis/manifests/deis-router-rc.yaml
+curl http://deis.<platform domain>/v2/
 ```
 
-After a moment or two, you should be able to test with a brief curl
-command:
+Since such requests require authentication, a response such as
+the following is an indicator of success:
 
 ```
-curl http://deis.10.245.1.3.xip.io/v2/
 {"detail":"Authentication credentials were not provided."}
 ```
 
-This message indicates that the message has been routed all the way to
-the Deis controller.
+## Next Steps
 
 Now that you've finished provisioning a cluster, start [Using Deis][] to deploy your first
 application on Deis.


### PR DESCRIPTION
Many, many apologies... this is a rewrite of doc that @technosophos added just this morning.  After seeing @sgoings stumble over a few issues, I realized the docs had to be a bit more descriptive in terms of the possible paths on can take to set this up (or may be forced to take, depending on the capabilities of their cluster and underlying infrastructure).

Essentially, this now documents three paths:

1.  Running where the "cloud provider" was able to provision an external load balancer connected to the router service.

2. Running where the above is _not_ true, but you are still able to provision your own load balancer.

3. Where 1 and 2 both don't work... i.e. Vagrant.

Don't anyone be shy about feedback on this PR.  These changes are extensive and I want to be super certain that the directions would be crystal clear to the average Deis operator.