### PR TITLE
feat(secrets): add support for deis minio secrets

### DIFF
--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -37,7 +37,13 @@ spec:
           volumeMounts:
             - mountPath: /var/run/docker.sock
               name: docker-socket
+            - name: minio-user
+              mountPath: /var/run/secrets/deis/minio/user
+              readOnly: true
       volumes:
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+        - name: minio-user
+          secret:
+            secretName: minio-user


### PR DESCRIPTION
mounted secret volumes in workflow and slugrunner template.
creates a new secret minio user in app namespace by reading files from mounts.
Creates namespace, services and Secrets first and then RC.

requires https://github.com/deis/slugrunner/pull/5
Todo// decide whether to read secret from api server or mount secrets to workflow ?
Todo// default port is 5000. Need a way to specify ports 
if you are testing using helm dont forget to add volume mounts for deis-workflow-rc.yaml in your helm workspace.

Added by Aaron on 12/18/2015 to auto close issues:

Fixes https://github.com/deis/slugrunner/issues/6