### PR TITLE
Small test fixes

### DIFF
--- a/_tests/tests_suite_test.go
+++ b/_tests/tests_suite_test.go
@@ -42,9 +42,7 @@ var (
 
 var _ = BeforeSuite(func() {
 	workflowHost := os.Getenv("DEIS_WORKFLOW_SERVICE_HOST")
-	workflowPort := os.Getenv("DEIS_WORKFLOW_SERVICE_PORT")
 	Expect(workflowHost).ShouldNot(BeEmpty())
-	Expect(workflowPort).ShouldNot(BeEmpty())
 	// use the "deis" executable in the search $PATH
 	_, err := exec.LookPath("deis")
 	Expect(err).NotTo(HaveOccurred())

--- a/_tests/tests_suite_test.go
+++ b/_tests/tests_suite_test.go
@@ -45,7 +45,9 @@ var _ = BeforeSuite(func() {
 	workflowPort := os.Getenv("DEIS_WORKFLOW_SERVICE_PORT")
 	Expect(workflowHost).ShouldNot(BeEmpty())
 	Expect(workflowPort).ShouldNot(BeEmpty())
-	Expect("../client/deis").Should(BeAnExistingFile())
+	// use the "deis" executable in the search $PATH
+	_, err := exec.LookPath("deis")
+	Expect(err).NotTo(HaveOccurred())
 
 	// register the test-admin user
 	register(url, testAdminUser, testAdminPassword, testAdminEmail)


### PR DESCRIPTION
Removes the `example-go` app that was accidentally checked in to version control. Also stops checking for optional `DEIS_WORKFLOW_SERVICE_PORT` and doesn't hard-code the location of the `deis` CLI.