### PR TITLE
fix(travis): deploy client on every push to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ deploy:
     key:
       secure: "JVCyPvXZIabZBhWgZ2wX4UDoTpIAjVnp+Ox6cXywYbACzKZSTz6G1kFcItzpUiEygUtye1213Zb+2050jq3BK7wohy5lcZCDJgrhyw6RxTRWIQQ5o+pS+O/AOYCSbpPn2E5goNutAhlOVsf2TlXkt4wz0jl5qOaecm0QXoiXBPUH5H1a3ifnCylybVG2jc2Kj/9S5uMGDQqocrPTXedZo9E/Es61MbKttlJGfcIrjbS71J8QZvDTcTSjzGT5CVdQulzkLNmFI5y31XwBE9XC6ro/Can10bIvy6yzYSWraUBTXVLWY2mPrPSlohOqNiYg2goQFQ2KwAGe6mVbq3UqOrYqNLXDdpSnCsRkx2KBw+ifET+0neq1NI3v5oSjKZ+p2zKCWQoOxahU40Eg+hA12oN17yHglaj2PGLuxYicDc+BQEGcGdBHAPJNXALd+rSDCdq5Gnd9HsCQE2Tyc+YK2bKvfpgcQNLS7gtiIxoRLZ1/qRBq3SB3IyQik7jjPe9Y0Meqnmdk8PeXM113/MSGdqZtVfyaOcT8SPgN22dhV42fs/BQtplTT3Hcs3yhmDwtl1w1udynerHcWx0PqZFn3h95SozJFPi8UdsbZog5V/CY/OAFs3K4bm3ay4Re1r2vTFCRuukp6UwtT5QR4kjsKWrLkewFbjId2FazJA8kMc4="
     on:
-      tags: true
       branch: master
 addons:
   artifacts:


### PR DESCRIPTION
Travis' `on` condition is an AND operation, so essentially in its
current configuration no client builds will be produced because
the build must be

1) from a merge to master AND
2) a tagged release

We have branching logic in `make prep-bintray-manifest` that will
deploy client builds to either deisci or to the deis org depending
on if the commit is from a tag or not, so we should deploy on
every PR so the deisci org is filled to the brim with cilent builds.