### PR TITLE
fix(bintray): add uploadPattern to bintray json

### DIFF
--- a/_scripts/ci/bintray-template.json
+++ b/_scripts/ci/bintray-template.json
@@ -8,9 +8,7 @@
     "name": "0.0.0"
   },
   "files": [
-    {
-      "includePattern": "client/deis"
-    }
+    { "includePattern": "client/deis", "uploadPattern": "deis" }
   ],
   "publish": true
 }


### PR DESCRIPTION
The uploadPattern is a required field that specifies the upload path
on Bintray.

fixes #144