### PR TITLE
feat(manifests): add k8s readiness check

### DIFF
--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -17,6 +17,12 @@ spec:
       containers:
         - name: deis-workflow
           image: quay.io/deisci/workflow:v2-alpha
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           livenessProbe:
             httpGet:
               path: /health-check


### PR DESCRIPTION
Adds a k8s [readiness check](http://kubernetes.io/v1.1/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks) to workflow, in addition to the existing liveness check.