### PR TITLE
fix(docs): hotfix oneliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ available in the [docs folder](https://github.com/deis/workflow/tree/master/docs
 If you want to retrieve the latest client dev build for OS X or Linux, download the client:
 
 ```console
-$ curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | sh
+$ curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash
 ```
 
 If you want to hack on a new feature, build the deis/workflow image and push it to a Docker

--- a/docs/src/using-deis/installing-the-client.md
+++ b/docs/src/using-deis/installing-the-client.md
@@ -8,7 +8,7 @@ with a Deis [Controller][]. You must install the client to use Deis.
 
 Install the latest `deis` client for Linux or Mac OS X with:
 
-    $ curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | sh
+    $ curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash
 
 The installer puts `deis` in your current directory, but you should move it
 somewhere in your $PATH:


### PR DESCRIPTION
`set -o pipefail` is an illegal option for /bin/sh. switch to /bin/bash