### PR TITLE
doc(*): strike references to logspout

### DIFF
--- a/docs/src/contributing/triaging-issues.md
+++ b/docs/src/contributing/triaging-issues.md
@@ -50,7 +50,6 @@ security     | Security-related issues such as TLS encryption, network segregati
 - etcd/fleet
 - kubernetes
 - logger
-- logspout
 - publisher
 - registry
 - router

--- a/docs/src/roadmap/release-checklist.md
+++ b/docs/src/roadmap/release-checklist.md
@@ -39,7 +39,6 @@ $ ./contrib/bumpver/bumpver -f A.B.C A.B.D \
     docs/reference/api-v1.7.rst \
     docs/troubleshooting_deis/index.rst \
     logger/image/Dockerfile \
-    logspout/image/Dockerfile \
     mesos/template \
     mesos/zookeeper/Dockerfile \
     publisher/image/Dockerfile \

--- a/docs/src/understanding-deis/architecture.md
+++ b/docs/src/understanding-deis/architecture.md
@@ -43,7 +43,6 @@ The platform scheduler is in charge of placing containers on hosts in the data p
 Deis also requires a few lightweight components on these hosts:
 
  * [publisher][] - publishes end-user containers to the [router][]
- * [logspout][] - feeds log data to the Control Plane [logger][]
 
 ## Router Mesh
 
@@ -75,7 +74,6 @@ See [Isolating the Planes][isolating-planes] for further details.
 [database]: components.md#database
 [isolating-planes]: ../managing-deis/isolating-the-planes.md
 [logger]: components.md#logger
-[logspout]: components.md#logspout
 [publisher]: components.md#publisher
 [registry]: components.md#registry
 [router]: components.md#router

--- a/docs/src/understanding-deis/components.md
+++ b/docs/src/understanding-deis/components.md
@@ -35,16 +35,9 @@ The builder component uses a [Git][] server to process
 The registry component hosts [Docker][] images on behalf of the platform.
 Image data is stored by [Store][].
 
-## Logspout
-
-The logspout component is a customized version of [progrium's logspout][] that runs
-on all CoreOS hosts in the cluster and collects logs from running containers.
-It sends the logs to the [logger][] component.
-
 ## Logger
 
-The logger component is a syslog server that collects logs from [logspout][]
-components spread across the platform.
+The logger component is a syslog server that collects logs from across the platform.
 This data can then be queried by the [Controller][].
 
 ## Publisher
@@ -73,11 +66,9 @@ and [Logger][].
 [etcd]: https://github.com/coreos/etcd
 [Git]: http://git-scm.com/
 [logger]: #logger
-[logspout]: #logspout
 [Nginx]: http://nginx.org/
 [OpenStack Storage]: http://www.openstack.org/software/openstack-storage/
 [PostgreSQL]: http://www.postgresql.org/
-[progrium's logspout]: https://github.com/progrium/logspout
 [Redis]: http://redis.io/
 [registry]: #registry
 [release]: ../reference-guide/terms.md#release


### PR DESCRIPTION
Partially addresses #161 

The documentation requires a comprehensive overhaul, but to keep PRs reasonable in scope, I'm limiting this to simple removal of references to a component that no longer exists.  A series of PRs such as this will incrementally address #161.