### PR TITLE
doc(*): strike references to logger

### DIFF
--- a/docs/src/contributing/submitting-a-pull-request.md
+++ b/docs/src/contributing/submitting-a-pull-request.md
@@ -53,7 +53,7 @@ git commit messages must follow this format:
 
 ### Example
 
-    feat(logger): add frobnitz pipeline spout discovery
+    feat(workflow): add frobnitz pipeline spout discovery
 
     Introduces a FPSD component compatible with the industry standard for
     spout discovery.

--- a/docs/src/contributing/testing.md
+++ b/docs/src/contributing/testing.md
@@ -91,7 +91,7 @@ make -C tests/ test-full
 
 Run the tests for a single component this way:
 
-    $ make -C logger test            # unit + functional
+    $ make -C database test            # unit + functional
     $ make -C controller test-unit
     $ make -C router test-functional
 

--- a/docs/src/contributing/triaging-issues.md
+++ b/docs/src/contributing/triaging-issues.md
@@ -48,7 +48,6 @@ security     | Security-related issues such as TLS encryption, network segregati
 - deisctl
 - docs
 - kubernetes
-- logger
 - registry
 - router
 - store (Ceph)

--- a/docs/src/roadmap/release-checklist.md
+++ b/docs/src/roadmap/release-checklist.md
@@ -37,7 +37,6 @@ $ ./contrib/bumpver/bumpver -f A.B.C A.B.D \
     docs/managing_deis/upgrading-deis.rst \
     docs/reference/api-v1.7.rst \
     docs/troubleshooting_deis/index.rst \
-    logger/image/Dockerfile \
     registry/Dockerfile \
     router/Dockerfile \
     store/base/Dockerfile \

--- a/docs/src/understanding-deis/architecture.md
+++ b/docs/src/understanding-deis/architecture.md
@@ -28,7 +28,6 @@ for the control plane's stateful components:
 
  * [registry][] - a Docker registry used to hold images and configuration data
  * [database][] - a Postgres database used to store platform state
- * [logger][] - a syslog log server that holds aggregated logs from the data plane
 
 End-users interact primarily with the [controller][] which exposes an
 HTTP API. They can also interact with the [builder][] via `git push`.
@@ -70,7 +69,6 @@ See [Isolating the Planes][isolating-planes] for further details.
 [controller]: components.md#controller
 [database]: components.md#database
 [isolating-planes]: ../managing-deis/isolating-the-planes.md
-[logger]: components.md#logger
 [registry]: components.md#registry
 [router]: components.md#router
 [store]: components.md#store

--- a/docs/src/understanding-deis/components.md
+++ b/docs/src/understanding-deis/components.md
@@ -35,11 +35,6 @@ The builder component uses a [Git][] server to process
 The registry component hosts [Docker][] images on behalf of the platform.
 Image data is stored by [Store][].
 
-## Logger
-
-The logger component is a syslog server that collects logs from across the platform.
-This data can then be queried by the [Controller][].
-
 ## Router
 
 The router component uses [Nginx][] to route traffic to application containers.
@@ -47,8 +42,7 @@ The router component uses [Nginx][] to route traffic to application containers.
 ## Store
 
 The store component uses [Ceph][] to store data for Deis components
-which need to store state, including [Registry][], [Database][]
-and [Logger][].
+which need to store state, including [Registry][], [Database][].
 
 [Amazon S3]: http://aws.amazon.com/s3/
 [Application]: ../reference-guide/terms.md#application
@@ -59,7 +53,6 @@ and [Logger][].
 [database]: #database
 [Docker]: http://docker.io/
 [Git]: http://git-scm.com/
-[logger]: #logger
 [Nginx]: http://nginx.org/
 [OpenStack Storage]: http://www.openstack.org/software/openstack-storage/
 [PostgreSQL]: http://www.postgresql.org/


### PR DESCRIPTION
Another PR that partially addresses #161 

Logger is neither included in nor a dependency of workflow ATM.  It's an add-on that requires a specially configured k8s cluster.