### PR TITLE
doc(*): strike references to schedulers that aren't k8s

### DIFF
--- a/docs/src/contributing/triaging-issues.md
+++ b/docs/src/contributing/triaging-issues.md
@@ -47,7 +47,6 @@ security     | Security-related issues such as TLS encryption, network segregati
 - database
 - deisctl
 - docs
-- etcd/fleet
 - kubernetes
 - logger
 - publisher

--- a/docs/src/installing-deis/system-requirements.md
+++ b/docs/src/installing-deis/system-requirements.md
@@ -11,7 +11,7 @@ Deis components consume approximately 2 - 2.5GB of memory across the cluster, an
 
 Note that these estimates are for Deis and CoreOS only, and there should be ample room for deployed applications.
 
-Running smaller machines will likely result in increased system load and has been known to result in component failures, issues with etcd/fleet, and other problems.
+Running smaller machines will likely result in increased system load and has been known to result in component failures and other problems.
 
 ## Cluster Size
 

--- a/docs/src/roadmap/release-checklist.md
+++ b/docs/src/roadmap/release-checklist.md
@@ -39,13 +39,10 @@ $ ./contrib/bumpver/bumpver -f A.B.C A.B.D \
     docs/reference/api-v1.7.rst \
     docs/troubleshooting_deis/index.rst \
     logger/image/Dockerfile \
-    mesos/template \
-    mesos/zookeeper/Dockerfile \
     publisher/image/Dockerfile \
     registry/Dockerfile \
     router/Dockerfile \
     store/base/Dockerfile \
-    swarm/image/Dockerfile \
     version/version.go
 ```
 

--- a/docs/src/roadmap/roadmap.md
+++ b/docs/src/roadmap/roadmap.md
@@ -23,15 +23,6 @@ of etcd in Deis, with a focus on performance and reliability.
 
 This feature is tracked as GitHub issue [#4404][].
 
-## New Default Scheduler
-
-Deis now has support for Docker Swarm, Apache Mesos, and Google Kubernetes as
-application schedulers. With the known limitations of fleet (primarily, not being
-a resource-aware scheduler), we should investigate using a different scheduler
-as our default.
-
-This feature is tracked as GitHub issue [#4222][].
-
 ## Permissions and Teams
 
 Deis deployments in larger organizations require more fine-grained control

--- a/docs/src/using-deis/managing-an-application.md
+++ b/docs/src/using-deis/managing-an-application.md
@@ -118,24 +118,6 @@ CPU shares are on a scale of 0 to 1024, with 1024 being all CPU resources on the
     the `limits:set` command will hang.  If this happens, use CTRL-C
     to break out of `limits:set` and use `limits:unset` to revert.
 
-
-## Isolate the Application
-
-Deis supports isolating applications onto a set of hosts using `tags`.
-
-!!! note
-    In order to use tags, you must first launch your hosts with
-    the proper key/value tag information.  If you do not, tag commands will fail.
-    Learn more by reading the [machine metadata][] section of Fleet documentation.
-
-Once your hosts are configured with appropriate key/value metadata, use
-`deis tags:set` to restrict the application to those hosts:
-
-    $ deis tags:set environ=prod
-    Applying tags...  done, v4
-
-    environ  prod
-
 [application]: ../reference-guide/terms.md#application
 [container]: ../reference-guide/terms.md#container
 [store config in environment variables]: http://12factor.net/config
@@ -144,4 +126,3 @@ Once your hosts are configured with appropriate key/value metadata, use
 [treat logs as event streams]: http://12factor.net/logs
 [use one-off processes for admin tasks]: http://12factor.net/admin-processes
 [Procfile]: http://ddollar.github.io/foreman/#PROCFILE
-[machine metadata]: https://coreos.com/docs/launching-containers/launching/fleet-unit-files/#user-defined-requirements


### PR DESCRIPTION
Partially addresses #161