### PR TITLE
feat(secrets): read secrets from apiserver

### DIFF
--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -37,13 +37,7 @@ spec:
           volumeMounts:
             - mountPath: /var/run/docker.sock
               name: docker-socket
-            - name: minio-user
-              mountPath: /var/run/secrets/deis/minio/user
-              readOnly: true
       volumes:
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
-        - name: minio-user
-          secret:
-            secretName: minio-user


### PR DESCRIPTION
```
$ kubectl get pods --namespace=atomic-electron
NAME                           READY     REASON    RESTARTS   AGE
atomic-electron-v2-web-c8ftn   1/1       Running   0          48s
$ deis ps
=== atomic-electron Processes
--- web:
web.1 up (v2)
[vagrant@kubernetes-minion-1 example-go]$ curl http://atomic-electron.10.245.1.4.xip.io
Powered by Deis
Release v2 on atomic-electron-v2-web-c8ftn
```
This PR addreses change of secrets problem in the issue https://github.com/deis/workflow/issues/140