### PR TITLE
fix(tests_suite_test.go): seed the rng, use true random numbers for users, passwords and emails

### DIFF
--- a/_tests/tests_suite_test.go
+++ b/_tests/tests_suite_test.go
@@ -37,12 +37,13 @@ func TestTests(t *testing.T) {
 }
 
 var (
-	testAdminUser     = fmt.Sprintf("test-admin-%d", rand.Intn(1000))
+	randSuffix        = rand.Intn(1000)
+	testAdminUser     = fmt.Sprintf("test-admin-%d", randSuffix)
 	testAdminPassword = "asdf1234"
-	testAdminEmail    = fmt.Sprintf("test-admin-%d@deis.io", rand.Intn(1000))
-	testUser          = fmt.Sprintf("test-%d", rand.Intn(1000))
+	testAdminEmail    = fmt.Sprintf("test-admin-%d@deis.io", randSuffix)
+	testUser          = fmt.Sprintf("test-%d", randSuffix)
 	testPassword      = "asdf1234"
-	testEmail         = fmt.Sprintf("test-%d@deis.io", rand.Intn(1000))
+	testEmail         = fmt.Sprintf("test-%d@deis.io", randSuffix)
 	url               = getController()
 )
 

--- a/_tests/tests_suite_test.go
+++ b/_tests/tests_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/config"
@@ -23,7 +24,7 @@ const (
 )
 
 func init() {
-	rand.Seed(GinkgoConfig.RandomSeed)
+	rand.Seed(time.Now().UnixNano())
 }
 
 func getRandAppName() string {
@@ -36,12 +37,12 @@ func TestTests(t *testing.T) {
 }
 
 var (
-	testAdminUser     = fmt.Sprintf("test-admin-%d", GinkgoConfig.RandomSeed)
+	testAdminUser     = fmt.Sprintf("test-admin-%d", rand.Intn(1000))
 	testAdminPassword = "asdf1234"
-	testAdminEmail    = fmt.Sprintf("test-admin-%d@deis.io", GinkgoConfig.RandomSeed)
-	testUser          = fmt.Sprintf("test-%d", GinkgoConfig.RandomSeed)
+	testAdminEmail    = fmt.Sprintf("test-admin-%d@deis.io", rand.Intn(1000))
+	testUser          = fmt.Sprintf("test-%d", rand.Intn(1000))
 	testPassword      = "asdf1234"
-	testEmail         = fmt.Sprintf("test-%d@deis.io", GinkgoConfig.RandomSeed)
+	testEmail         = fmt.Sprintf("test-%d@deis.io", rand.Intn(1000))
 	url               = getController()
 )
 


### PR DESCRIPTION
not strictly necessary for `v2.0-alpha1`, but the additional randomness would help with concurrent test runs on the same deis cluster