### PR TITLE
feat(_tests): run tests in a docker image (WIP)

### DIFF
--- a/_tests/Dockerfile
+++ b/_tests/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu-debootstrap:14.04
+
+COPY _tests.test .
+RUN mv _tests.test /bin
+RUN apt-get update -y && apt-get install -y curl
+RUN curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash && mv ./deis /bin/deis
+CMD _tests.test

--- a/_tests/Makefile
+++ b/_tests/Makefile
@@ -1,22 +1,32 @@
 export GO15VENDOREXPERIMENT=1
 
+SHORT_NAME := deis-e2e
+
 SRC_PATH := /go/src/github.com/deis/workflow/_tests
-DEV_IMG := quay.io/deis/go-dev:0.3.0
+DEV_IMG := quay.io/deis/go-dev:0.4.0
 DEIS_WORKFLOW_SERVICE_HOST ?= deis.172.17.8.100:8080
-DEV_CMD := docker run --rm -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
+
+RUN_CMD := docker run --rm -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
+
+DEV_CMD := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
+
+VERSION ?= git-$(shell git rev-parse --short HEAD)
+DEIS_REGISTRY ?= quay.io/
+IMAGE_PREFIX ?= deis
+IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
 
 bootstrap:
 	${DEV_CMD} glide install
-	# Once the TODO below is complete, this line can be removed
-	go get github.com/onsi/ginkgo/ginkgo
 
 test-integration:
-	${DEV_CMD} go test -v .
+	${RUN_CMD} go test -v .
 
-build:
 # Precompile the test suite into a binary "_tests.test"
- 	# TODO: https://github.com/deis/docker-go-dev/pull/8 is now merged into that repositories master branch.
-	# When the repository is tagged as 0.4.0, our CI will build a 'quay.io/deis/go-dev:0.4.0' image that has
-	# the ginkgo binary. After that, this command should move to use DEV_CMD. This work is tracked in
-	# https://github.com/deis/workflow/issues/139
-	ginkgo build -race -r
+build:
+	${DEV_CMD} ginkgo build -race -r
+
+docker-build:
+	docker build -t ${IMAGE} ${CURDIR}
+
+docker-test-integration:
+	docker run -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} ${IMAGE}

--- a/_tests/Makefile
+++ b/_tests/Makefile
@@ -28,5 +28,8 @@ build:
 docker-build: build
 	docker build -t ${IMAGE} ${CURDIR}
 
+docker-push:
+	docker push ${IMAGE}
+
 docker-test-integration:
 	docker run -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} ${IMAGE}

--- a/_tests/Makefile
+++ b/_tests/Makefile
@@ -1,11 +1,22 @@
+export GO15VENDOREXPERIMENT=1
 
-test-setup:
+SRC_PATH := /go/src/github.com/deis/workflow/_tests
+DEV_IMG := quay.io/deis/go-dev:0.3.0
+DEIS_WORKFLOW_SERVICE_HOST ?= deis.172.17.8.100:8080
+DEV_CMD := docker run --rm -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
+
+bootstrap:
+	${DEV_CMD} glide install
+	# Once the TODO below is complete, this line can be removed
 	go get github.com/onsi/ginkgo/ginkgo
-	go get github.com/onsi/gomega
 
 test-integration:
-	go test -v -ginkgo.v ./...
+	${DEV_CMD} go test -v .
 
 build:
 # Precompile the test suite into a binary "_tests.test"
+ 	# TODO: https://github.com/deis/docker-go-dev/pull/8 is now merged into that repositories master branch.
+	# When the repository is tagged as 0.4.0, our CI will build a 'quay.io/deis/go-dev:0.4.0' image that has
+	# the ginkgo binary. After that, this command should move to use DEV_CMD. This work is tracked in
+	# https://github.com/deis/workflow/issues/139
 	ginkgo build -race -r

--- a/_tests/Makefile
+++ b/_tests/Makefile
@@ -25,7 +25,7 @@ test-integration:
 build:
 	${DEV_CMD} ginkgo build -race -r
 
-docker-build:
+docker-build: build
 	docker build -t ${IMAGE} ${CURDIR}
 
 docker-test-integration:

--- a/_tests/glide.lock
+++ b/_tests/glide.lock
@@ -1,0 +1,10 @@
+hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+updated: 2015-12-22T16:20:42.781138-08:00
+imports:
+- name: github.com/golang/protobuf
+  version: 68415e7123da32b07eab49c96d2c4d6158360e9b
+- name: github.com/onsi/ginkgo
+  version: e43390e35a4a88f3f95d5ddf9055efb7a1170469
+- name: github.com/onsi/gomega
+  version: 0fe204460da2c8fa1babcaac196e694de8f1aaa1
+devImports: []

--- a/_tests/glide.yaml
+++ b/_tests/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/deis/workflow/_tests
+import:
+  - package: github.com/onsi/ginkgo
+  - package: github.com/onsi/gomega


### PR DESCRIPTION
Fixes #193
Fixes #139

TODO:

- [x] Tag and build a 0.4.0 docker image from https://github.com/deis/docker-go-dev/pull/8  (which has been merged)
- [x] Get a `deis` client into the integration testing Docker image (it may have to be different from the one generated by https://github.com/deis/docker-go-dev)
- [ ] make a k8s pod manifest for the image