### PR TITLE
doc(contributing): update contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,101 +1,43 @@
 # How to Contribute
 
-The Deis project is Apache 2.0 licensed and accepts contributions via Github pull
-requests. This document outlines some of the conventions on commit message formatting,
-contact points for developers and other resources to make getting your contribution
-accepted.
+Deis components are Apache 2.0 licensed and accept contributions via Github pull requests. This document outlines resources and conventions useful for anyone wishing to contribute either by reporting issues or submitting pull requests.
 
 # Certificate of Origin
 
-By contributing to this project you agree to the
-[Developer Certificate of Origin (DCO)][dco]. This document was created by the Linux
-Kernel community and is a simple statement that you, as a contributor, have the legal
-right to make the contribution.
+By contributing to any Deis project you agree to its [Developer Certificate of Origin (DCO)][dco]. This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution.
 
 # Support Channels
 
-Before opening a new issue, it's helpful to search the project - it's likely that another user
-has already reported the issue you're facing, or it's a known issue that we're already aware of.
+Before opening a new issue or PR against any Deis project, it's helpful to search that project's issue queue - it's likely that another user has already reported the issue you're facing, or it's a known issue that we're already aware of.
 
-Additionally, see the [Troubleshooting Deis][troubleshooting] documentation for common issues.
+A consolidated view of open issues and pull requests for all Deis projects is available [here][issues].
+
+Additionally, see the [Troubleshooting][] documentation for common issues.
 
 Our official support channels are:
 
-- GitHub issues: https://github.com/deis/deis/issues/new
+- GitHub issue queues:
+  - builder: https://github.com/deis/builder/issues
+  - chart: https://github.com/deis/charts/issues
+  - database: https://github.com/deis/postgres/issues
+  - etcd: https://github.com/deis/etcd/issues
+  - helm: https://github.com/helm/helm/issues
+  - minio: https://github.com/deis/minio/issues
+  - registry: https://github.com/deis/registry/issues
+  - router: https://github.com/deis/router/issues
+  - workflow: https://github.com/deis/workflow/issues
+	- All other public [Deis repositories][repos]
 - IRC: #[deis](irc://irc.freenode.org:6667/#deis) IRC channel on freenode.org
 
 ## Getting Started
 
-- Fork the repository on GitHub
-- Read [the documentation](http://docs.deis.io/en/latest/contributing/hacking/) for build instructions
+The [Development Environment][dev-environment] documentation extensively details procedures for setting up a development environment and outlines the contribution workflow.
 
-## Contribution Flow
-
-This is a rough outline of what a contributor's workflow looks like:
-
-- Create a topic branch from where you want to base your work. This is usually master.
-- Make commits of logical units.
-- Make sure your commit messages are in the proper format, see below
-- Push your changes to a topic branch in your fork of the repository.
-- Submit a pull request
-
-Thanks for your contributions!
-
-### Design Documents
-
-Most substantial changes to Deis should follow a [Design Document](http://docs.deis.io/en/latest/contributing/design-documents/)
-describing the proposed changes and how they are tested and verified before they
-are accepted into the project.
-
-### Commit Style Guideline
-
-We follow a rough convention for commit messages borrowed from CoreOS, who borrowed theirs
-from AngularJS. This is an example of a commit:
-
-    feat(scripts/test-cluster): add a cluster test command
-
-    this uses tmux to setup a test cluster that you can easily kill and
-    start for debugging.
-
-To make it more formal, it looks something like this:
-
-
-    {type}({scope}): {subject}
-    <BLANK LINE>
-    {body}
-    <BLANK LINE>
-    {footer}
-
-The {scope} can be anything specifying place of the commit change.
-
-The {subject} needs to use imperative, present tense: “change”, not “changed” nor
-“changes”. The first letter should not be capitalized, and there is no dot (.) at the end.
-
-Just like the {subject}, the message {body} needs to be in the present tense, and includes
-the motivation for the change, as well as a contrast with the previous behavior. The first
-letter in a paragraph must be capitalized.
-
-All breaking changes need to be mentioned in the {footer} with the description of the
-change, the justification behind the change and any migration notes required.
-
-Any line of the commit message cannot be longer than 72 characters, with the subject line
-limited to 50 characters. This allows the message to be easier to read on github as well
-as in various git tools.
-
-The allowed {types} are as follows:
-
-    feat -> feature
-    fix -> bug fix
-    docs -> documentation
-    style -> formatting
-    ref -> refactoring code
-    test -> adding missing tests
-    chore -> maintenance
-
-### More Details on Commits
-
-For more details see the [commit style guide][style-guide].
+[Submitting a Pull Request][pr] documents stylistic conventions that help Deis maintainers to more easily review and accept your PRs.
 
 [dco]: DCO
-[style-guide]: http://docs.deis.io/en/latest/contributing/standards/#commit-style-guide
-[troubleshooting]: http://docs.deis.io/en/latest/troubleshooting_deis/
+[issues]: https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+user%3Adeis+user%3Ahelm
+[repos]: https://github.com/deis
+[troubleshooting]: docs/src/troubleshooting/troubleshooting.md
+[dev-environment]: docs/src/contributing/development-environment.md
+[pr]: docs/src/contributing/submitting-a-pull-request.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,7 +46,7 @@ pages:
   - Customizing Deis:
     - CLI Plugins: customizing-deis/cli-plugins.md
   - Troubleshooting:
-    - Troubleshooting with kubectl: troubleshooting/troubleshooting-with-kubectl.md
+    - Troubleshooting with kubectl: troubleshooting/troubleshooting.md
   - Roadmap:
     - Planning Process: roadmap/planning-process.md
     - Roadmap: roadmap/roadmap.md

--- a/docs/src/contributing/submitting-a-pull-request.md
+++ b/docs/src/contributing/submitting-a-pull-request.md
@@ -41,50 +41,51 @@ Python code should always adhere to [PEP8][], the python code style guide, with 
 
 ## Commit Style
 
-git commit messages must follow this format:
+We follow a convention for commit messages borrowed from CoreOS, who borrowed theirs
+from AngularJS. This is an example of a commit:
 
-    {type}({scope}): {subject}
-    <BLANK LINE>
-    {body}
-    <BLANK LINE>
-    {footer}
+```
+feat(scripts/test-cluster): add a cluster test command
 
-### Example
+this uses tmux to setup a test cluster that you can easily kill and
+start for debugging.
+```
 
-    feat(workflow): add frobnitz pipeline spout discovery
+To make it more formal, it looks something like this:
 
-    Introduces a FPSD component compatible with the industry standard for
-    spout discovery.
+```
+{type}({scope}): {subject}
+<BLANK LINE>
+{body}
+<BLANK LINE>
+{footer}
+```
 
-    BREAKING CHANGE: Fixing the buffer overflow in the master subroutine
-        required losing compatibility with the UVEX-9. Any UVEX-9 or
-        umVEX-8 series artifacts will need to be updated to umVX format
-        with the consortium or vendor toolset.
+The allowed `{types}` are as follows:
 
-### Subject Line
+* `feat` -> feature
+* `fix`` -> bug fix
+* `docs` -> documentation
+* `style` -> formatting
+* `ref` -> refactoring code
+* `test` -> adding missing tests
+* `chore` -> maintenance
 
-The first line of a commit message is its subject. It contains a brief description of the change, no longer than 50 characters.
+The `{scope}` can be anything specifying the location(s) of the commit change(s).
 
-These `{types}` are allowed:
+The `{subject}` needs to be an imperative, present tense verb: “change”, not “changed” nor
+“changes”. The first letter should not be capitalized, and there is no dot (.) at the end.
 
-- **feat** -> feature
-- **fix** -> bug fix
-- **docs** -> documentation
-- **style** -> formatting
-- **ref** -> refactoring code
-- **test** -> adding missing tests
-- **chore** -> maintenance
+Just like the `{subject}`, the message `{body}` needs to be in the present tense, and includes
+the motivation for the change, as well as a contrast with the previous behavior. The first
+letter in a paragraph must be capitalized.
 
-The `{scope}` specifies the location of the change, such as "Dockerfile," "tests", or "manifests". The `{subject}` should use an imperative, present-tense verb: "change," not "changes" or "changed." Don't capitalize the verb or add a period (.) at the end of the subject line.
+All breaking changes need to be mentioned in the `{footer}` with the description of the
+change, the justification behind the change and any migration notes required.
 
-### Message Body
-
-Separate the message body from the subject with a blank line. It includes the motivation for the change and points out differences from previous behavior. The body and the footer should be written as full sentences.
-
-### Message Footer
-
-Separate a footer from the message body with a blank line. Mention any breaking change along with the justification and migration notes. If the changes cannot be tested by Deis' test scripts, include specific instructions for manual testing.
-
+Any line of the commit message cannot be longer than 72 characters, with the subject line
+limited to 50 characters. This allows the message to be easier to read on GitHub as well
+as in various git tools.
 
 ## Merge Approval
 

--- a/docs/src/troubleshooting/troubleshooting.md
+++ b/docs/src/troubleshooting/troubleshooting.md
@@ -1,3 +1,3 @@
-# Troubleshooting with kubectl
+# Troubleshooting
 
 TODO (bacongobbler): rewrite for v2


### PR DESCRIPTION
Partially addresses both #161 and #185 

`contributing.md` was a bit stale.  It needed updates to reference additional support channels (multiple issue queues for individually repo'ed Deis components).  While editing, I noticed tremendous overlap with other documentation in `docs/src/contriubting`, so I simplified `contributing.md` to be a quicker read that references the more detailed docs where applicable.