### PR TITLE
ref(models): remove config interaction with Config model

### DIFF
--- a/rootfs/api/models.py
+++ b/rootfs/api/models.py
@@ -1207,32 +1207,6 @@ def _etcd_purge_cert(**kwargs):
         pass
 
 
-def _etcd_publish_config(**kwargs):
-    config = kwargs['instance']
-    # we purge all existing config when adding the newest instance. This is because
-    # deis config:unset would remove an existing value, but not delete the
-    # old config object
-    try:
-        _etcd_client.delete('/deis/config/{}'.format(config.app),
-                            prevExist=True, dir=True, recursive=True)
-    except KeyError:
-        pass
-    for k, v in config.values.iteritems():
-        _etcd_client.write(
-            '/deis/config/{}/{}'.format(
-                config.app,
-                unicode(k).encode('utf-8').lower()),
-            unicode(v).encode('utf-8'))
-
-
-def _etcd_purge_config(**kwargs):
-    config = kwargs['instance']
-    try:
-        _etcd_client.delete('/deis/config/{}'.format(config.app),
-                            prevExist=True, dir=True, recursive=True)
-    except KeyError:
-        pass
-
 # Log significant app-related events
 post_save.connect(_log_build_created, sender=Build, dispatch_uid='api.models.log')
 post_save.connect(_log_release_created, sender=Release, dispatch_uid='api.models.log')
@@ -1261,5 +1235,3 @@ if _etcd_client:
     post_delete.connect(_etcd_purge_app, sender=App, dispatch_uid='api.models')
     post_save.connect(_etcd_publish_cert, sender=Certificate, dispatch_uid='api.models')
     post_delete.connect(_etcd_purge_cert, sender=Certificate, dispatch_uid='api.models')
-    post_save.connect(_etcd_publish_config, sender=Config, dispatch_uid='api.models')
-    post_delete.connect(_etcd_purge_config, sender=Config, dispatch_uid='api.models')


### PR DESCRIPTION
Previously this was used by publisher for healthchecks and also the router for app level IP/CIDR whitelisting

Going to use #205 to start addressing the latter