### PR TITLE
ref(ldap): remove LDAP temporarily

### DIFF
--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -16,8 +16,6 @@ apk add --update-cache \
   curl \
   libffi-dev \
   libpq \
-  openldap \
-  openldap-dev \
   postgresql-dev \
   python \
   python-dev
@@ -42,7 +40,6 @@ apk del --purge \
   build-base \
   curl \
   libffi-dev \
-  openldap-dev \
   postgresql-dev \
   python-dev
 rm -rf /var/cache/apk/*

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -8,9 +8,6 @@ import random
 import string
 import sys
 import tempfile
-import ldap
-
-from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
 
 
 PROJECT_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
@@ -131,7 +128,6 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.staticfiles',
     # Third-party apps
-    'django_auth_ldap',
     'guardian',
     'jsonfield',
     'gunicorn',
@@ -145,7 +141,6 @@ INSTALLED_APPS = (
 )
 
 AUTHENTICATION_BACKENDS = (
-    "django_auth_ldap.backend.LDAPBackend",
     "django.contrib.auth.backends.ModelBackend",
     "guardian.backends.ObjectPermissionBackend",
 )
@@ -342,16 +337,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 #  server       - Hostname based on CoreOS server hostname
 UNIT_HOSTNAME = 'default'
 
-# LDAP DEFAULT SETTINGS (Overrided by confd later)
-LDAP_ENDPOINT = ""
-BIND_DN = ""
-BIND_PASSWORD = ""
-USER_BASEDN = ""
-USER_FILTER = ""
-GROUP_BASEDN = ""
-GROUP_FILTER = ""
-GROUP_TYPE = ""
-
 # Create a file named "local_settings.py" to contain sensitive settings data
 # such as database configuration, admin email, or passwords and keys. It
 # should also be used for any settings which differ between development
@@ -367,36 +352,3 @@ except ImportError:
 if os.path.exists('/templates/confd_settings.py'):
     sys.path.append('/templates')
     from confd_settings import *  # noqa
-
-# LDAP Backend Configuration
-# Should be always after the confd_settings import.
-LDAP_USER_SEARCH = LDAPSearch(
-    base_dn=USER_BASEDN,
-    scope=ldap.SCOPE_SUBTREE,
-    filterstr="(%s=%%(user)s)" % USER_FILTER
-)
-LDAP_GROUP_SEARCH = LDAPSearch(
-    base_dn=GROUP_BASEDN,
-    scope=ldap.SCOPE_SUBTREE,
-    filterstr="(%s=%s)" % (GROUP_FILTER, GROUP_TYPE)
-)
-AUTH_LDAP_SERVER_URI = LDAP_ENDPOINT
-AUTH_LDAP_BIND_DN = BIND_DN
-AUTH_LDAP_BIND_PASSWORD = BIND_PASSWORD
-AUTH_LDAP_USER_SEARCH = LDAP_USER_SEARCH
-AUTH_LDAP_GROUP_SEARCH = LDAP_GROUP_SEARCH
-AUTH_LDAP_GROUP_TYPE = GroupOfNamesType()
-AUTH_LDAP_USER_ATTR_MAP = {
-    "first_name": "givenName",
-    "last_name": "sn",
-    "email": "mail",
-    "username": USER_FILTER,
-}
-AUTH_LDAP_GLOBAL_OPTIONS = {
-    ldap.OPT_X_TLS_REQUIRE_CERT: False,
-    ldap.OPT_REFERRALS: False
-}
-AUTH_LDAP_ALWAYS_UPDATE_USER = True
-AUTH_LDAP_MIRROR_GROUPS = True
-AUTH_LDAP_FIND_GROUP_PERMS = True
-AUTH_LDAP_CACHE_GROUPS = False

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -6,13 +6,11 @@ django-cors-headers==1.0.0
 django-fsm==2.2.0
 django-guardian==1.2.5
 jsonfield==1.0.3
-django-auth-ldap==1.2.5
 djangorestframework==3.0.5
 docker-py==1.6.0
 gunicorn==19.3.0
 psycopg2==2.6.1
 python-etcd==0.3.2
-python-ldap==2.4.19
 PyYAML==3.11
 requests==2.8.1
 simpleflock==0.0.2

--- a/rootfs/templates/confd_settings.py
+++ b/rootfs/templates/confd_settings.py
@@ -20,16 +20,3 @@ REGISTRATION_MODE = '{{ getv "/deis/controller/registrationMode" }}'
 {{ if exists "/deis/controller/subdomain" }}
 DEIS_RESERVED_NAMES = ['{{ getv "/deis/controller/subdomain" }}']
 {{ end }}
-
-# AUTH
-# LDAP
-{{ if exists "/deis/controller/auth/ldap/endpoint" }}
-LDAP_ENDPOINT = '{{ if exists "/deis/controller/auth/ldap/endpoint" }}{{ getv "/deis/controller/auth/ldap/endpoint"}}{{ else }} {{ end }}'
-BIND_DN = '{{ if exists "/deis/controller/auth/ldap/bind/dn" }}{{ getv "/deis/controller/auth/ldap/bind/dn"}}{{ else }} {{ end }}'
-BIND_PASSWORD = '{{ if exists "/deis/controller/auth/ldap/bind/password" }}{{ getv "/deis/controller/auth/ldap/bind/password"}}{{ else }} {{ end }}'
-USER_BASEDN = '{{ if exists "/deis/controller/auth/ldap/user/basedn" }}{{ getv "/deis/controller/auth/ldap/user/basedn"}}{{ else }} {{ end }}'
-USER_FILTER = '{{ if exists "/deis/controller/auth/ldap/user/filter" }}{{ getv "/deis/controller/auth/ldap/user/filter"}}{{ else }} {{ end }}'
-GROUP_BASEDN = '{{ if exists "/deis/controller/auth/ldap/group/basedn" }}{{ getv "/deis/controller/auth/ldap/group/basedn"}}{{ else }} {{ end }}'
-GROUP_FILTER = '{{ if exists "/deis/controller/auth/ldap/group/filter" }}{{ getv "/deis/controller/auth/ldap/group/filter"}}{{ else }} {{ end }}'
-GROUP_TYPE = '{{ if exists "/deis/controller/auth/ldap/group/type" }}{{ getv "/deis/controller/auth/ldap/group/type"}}{{ else }} {{ end }}'
-{{ end }}


### PR DESCRIPTION
LDAP poses a problem with the upgrade path to Django 1.9 as the modules involved are not compatible.
Removing until we have a better identity and federation story. And the django plugin works again

Ref #207