### PR TITLE
fix(tests_suite_test.go): cancel accounts gracefully in the AfterSuite block

### DIFF
--- a/_tests/tests_suite_test.go
+++ b/_tests/tests_suite_test.go
@@ -3,7 +3,6 @@ package _tests_test
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"math/rand"
 	"os"
 	"os/exec"

--- a/_tests/tests_suite_test.go
+++ b/_tests/tests_suite_test.go
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	cancelUserSess, cancelUserErr := cancelSess(url, testUser, testPassword)
-	cancelAdminSess, cancelAdminErr := cancelSess(url, testAdminEmail, testAdminPassword)
+	cancelAdminSess, cancelAdminErr := cancelSess(url, testAdminUser, testAdminPassword)
 	Expect(cancelUserErr).To(BeNil())
 	Expect(cancelAdminErr).To(BeNil())
 	cancelUserSess.Wait()


### PR DESCRIPTION
This patch makes the code in `AfterSuite` attempt to delete both users, even if the first fails. Combined with https://github.com/deis/workflow/pull/191, this will at least help with error reporting and graceful cleanup

cc/ @lanej @michelleN 