### PR TITLE
ref(*): remove the notion of a platform domain known to workflow

### DIFF
--- a/client/controller/api/apps.go
+++ b/client/controller/api/apps.go
@@ -6,7 +6,7 @@ type App struct {
 	ID      string `json:"id"`
 	Owner   string `json:"owner"`
 	Updated string `json:"updated"`
-	URL     string `json:"url"`
+	URL     string `json:"-"`
 	UUID    string `json:"uuid"`
 }
 

--- a/client/controller/models/apps/apps.go
+++ b/client/controller/models/apps/apps.go
@@ -23,6 +23,12 @@ func List(c *client.Client, results int) ([]api.App, int, error) {
 		return []api.App{}, -1, err
 	}
 
+	for name, app := range apps {
+		// Add in app URL based on controller hostname, port included
+		app.URL = fmt.Sprintf("%s.%s", app.ID, c.ControllerURL.Host)
+		apps[name] = app
+	}
+
 	return apps, count, nil
 }
 
@@ -51,6 +57,9 @@ func New(c *client.Client, id string) (api.App, error) {
 		return api.App{}, err
 	}
 
+	// Add in app URL based on controller hostname, port included
+	app.URL = fmt.Sprintf("%s.%s", app.ID, c.ControllerURL.Host)
+
 	return app, nil
 }
 
@@ -69,6 +78,9 @@ func Get(c *client.Client, appID string) (api.App, error) {
 	if err = json.Unmarshal([]byte(body), &app); err != nil {
 		return api.App{}, err
 	}
+
+	// Add in app URL based on controller hostname, port included
+	app.URL = fmt.Sprintf("%s.%s", app.ID, c.ControllerURL.Host)
 
 	return app, nil
 }

--- a/client/controller/models/apps/apps_test.go
+++ b/client/controller/models/apps/apps_test.go
@@ -21,7 +21,6 @@ const appFixture string = `
     "owner": "test",
     "structure": {},
     "updated": "2014-01-01T00:00:00UTC",
-    "url": "example-go.example.com",
     "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
 }`
 
@@ -37,7 +36,6 @@ const appsFixture string = `
             "owner": "test",
             "structure": {},
             "updated": "2014-01-01T00:00:00UTC",
-            "url": "example-go.example.com",
             "uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
         }
     ]
@@ -157,15 +155,6 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 func TestAppsCreate(t *testing.T) {
 	t.Parallel()
 
-	expected := api.App{
-		ID:      "example-go",
-		Created: "2014-01-01T00:00:00UTC",
-		Owner:   "test",
-		Updated: "2014-01-01T00:00:00UTC",
-		URL:     "example-go.example.com",
-		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
-	}
-
 	handler := fakeHTTPServer{createID: false, createWithoutID: false}
 	server := httptest.NewServer(&handler)
 	defer server.Close()
@@ -174,6 +163,15 @@ func TestAppsCreate(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	expected := api.App{
+		ID:      "example-go",
+		Created: "2014-01-01T00:00:00UTC",
+		Owner:   "test",
+		Updated: "2014-01-01T00:00:00UTC",
+		URL:     fmt.Sprintf("example-go.%s", u.Host),
+		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
 	}
 
 	httpClient := client.CreateHTTPClient(false)
@@ -196,15 +194,6 @@ func TestAppsCreate(t *testing.T) {
 func TestAppsGet(t *testing.T) {
 	t.Parallel()
 
-	expected := api.App{
-		ID:      "example-go",
-		Created: "2014-01-01T00:00:00UTC",
-		Owner:   "test",
-		Updated: "2014-01-01T00:00:00UTC",
-		URL:     "example-go.example.com",
-		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
-	}
-
 	handler := fakeHTTPServer{}
 	server := httptest.NewServer(&handler)
 	defer server.Close()
@@ -213,6 +202,15 @@ func TestAppsGet(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	expected := api.App{
+		ID:      "example-go",
+		Created: "2014-01-01T00:00:00UTC",
+		Owner:   "test",
+		Updated: "2014-01-01T00:00:00UTC",
+		URL:     fmt.Sprintf("example-go.%s", u.Host),
+		UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
 	}
 
 	httpClient := client.CreateHTTPClient(false)
@@ -288,17 +286,6 @@ func TestAppsRun(t *testing.T) {
 func TestAppsList(t *testing.T) {
 	t.Parallel()
 
-	expected := []api.App{
-		{
-			ID:      "example-go",
-			Created: "2014-01-01T00:00:00UTC",
-			Owner:   "test",
-			Updated: "2014-01-01T00:00:00UTC",
-			URL:     "example-go.example.com",
-			UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
-		},
-	}
-
 	handler := fakeHTTPServer{}
 	server := httptest.NewServer(&handler)
 	defer server.Close()
@@ -307,6 +294,17 @@ func TestAppsList(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	expected := []api.App{
+		{
+			ID:      "example-go",
+			Created: "2014-01-01T00:00:00UTC",
+			Owner:   "test",
+			Updated: "2014-01-01T00:00:00UTC",
+			URL:     fmt.Sprintf("example-go.%s", u.Host),
+			UUID:    "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+		},
 	}
 
 	httpClient := client.CreateHTTPClient(false)

--- a/rootfs/api/models.py
+++ b/rootfs/api/models.py
@@ -184,10 +184,6 @@ class App(UuidAuditedModel):
     def __str__(self):
         return self.id
 
-    @property
-    def url(self):
-        return self.id + '.' + settings.DEIS_DOMAIN
-
     def _get_job_id(self, container_type):
         app = self.id
         release = self.release_set.latest()

--- a/rootfs/api/serializers.py
+++ b/rootfs/api/serializers.py
@@ -131,7 +131,7 @@ class AppSerializer(serializers.ModelSerializer):
     class Meta:
         """Metadata options for a :class:`AppSerializer`."""
         model = models.App
-        fields = ['uuid', 'id', 'owner', 'url', 'structure', 'created', 'updated']
+        fields = ['uuid', 'id', 'owner', 'structure', 'created', 'updated']
         read_only_fields = ['uuid']
 
 

--- a/rootfs/api/tests/test_app.py
+++ b/rootfs/api/tests/test_app.py
@@ -60,11 +60,10 @@ class AppTest(TestCase):
                                     content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         for key in response.data:
-            self.assertIn(key, ['uuid', 'created', 'updated', 'id', 'owner', 'url', 'structure'])
+            self.assertIn(key, ['uuid', 'created', 'updated', 'id', 'owner', 'structure'])
         expected = {
             'id': 'test',
             'owner': self.user.username,
-            'url': 'test.deisapp.local',
             'structure': {}
         }
         self.assertDictContainsSubset(expected, response.data)

--- a/rootfs/api/tests/test_hooks.py
+++ b/rootfs/api/tests/test_hooks.py
@@ -113,7 +113,6 @@ class HookTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('release', response.data)
         self.assertIn('version', response.data['release'])
-        self.assertIn('domains', response.data)
 
     def test_build_hook_procfile(self):
         """Test creating a Procfile build via an API Hook"""
@@ -139,7 +138,6 @@ class HookTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('release', response.data)
         self.assertIn('version', response.data['release'])
-        self.assertIn('domains', response.data)
         # make sure build fields were populated
         url = '/v2/apps/{app_id}/builds'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
@@ -183,7 +181,6 @@ class HookTest(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('release', response.data)
         self.assertIn('version', response.data['release'])
-        self.assertIn('domains', response.data)
         # make sure build fields were populated
         url = '/v2/apps/{app_id}/builds'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -405,8 +405,7 @@ class BuildHookViewSet(BaseHookViewSet):
         request.data['owner'] = self.user
         super(BuildHookViewSet, self).create(request, *args, **kwargs)
         # return the application databag
-        response = {'release': {'version': app.release_set.latest().version},
-                    'domains': ['.'.join([app.id, settings.DEIS_DOMAIN])]}
+        response = {'release': {'version': app.release_set.latest().version}}
         return Response(response, status=status.HTTP_200_OK)
 
     def post_save(self, build):

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -64,10 +64,6 @@ etcd_safe_mkdir /deis/platform
 etcd_safe_mkdir /deis/scheduler
 etcd_safe_mkdir /deis/services
 
-# HACK: set up keys for platform
-etcd_safe_mkdir /deis/platform
-ETCD_PATH=/deis/platform etcd_set_default domain localhost
-
 # wait for confd to run once and install initial templates
 until confd -onetime -node "$ETCD" --confdir /app --log-level error; do
 	echo "controller: waiting for confd to write initial templates..."

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -274,7 +274,6 @@ ETCD_PORT = os.environ.get('DEIS_ETCD_1_SERVICE_PORT_CLIENT', 4001)
 # default deis settings
 LOG_LINES = 1000
 TEMPDIR = tempfile.mkdtemp(prefix='deis')
-DEIS_DOMAIN = 'deisapp.local'
 
 # standard datetime format used for logging, model timestamps, etc.
 DEIS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%Z'

--- a/rootfs/templates/confd_settings.py
+++ b/rootfs/templates/confd_settings.py
@@ -10,9 +10,6 @@ SCHEDULER_URL = "https://{}:{}".format(
     os.environ.get('KUBERNETES_SERVICE_HOST', 'kubernetes.default.svc.cluster.local'),
     os.environ.get('KUBERNETES_SERVICE_PORT', '443'))
 
-# platform domain must be provided
-DEIS_DOMAIN = '{{ getv "/deis/platform/domain" }}'
-
 {{ if exists "/deis/controller/registrationMode" }}
 REGISTRATION_MODE = '{{ getv "/deis/controller/registrationMode" }}'
 {{ end }}


### PR DESCRIPTION
Addresses the workflow side of #111 but doesn't do the client part so that it opens up the right domain