### PR TITLE
feat(manifests): Make the workflow service routable

### DIFF
--- a/manifests/deis-workflow-service.yml
+++ b/manifests/deis-workflow-service.yml
@@ -4,10 +4,13 @@ metadata:
   name: deis-workflow
   labels:
     heritage: deis
+    routable: "true"
+  annotations:
+    router.deis.io/domains: deis
 spec:
   ports:
   - name: http
-    port: 8000
+    port: 80
     targetPort: 8000
     protocol: TCP
   selector:


### PR DESCRIPTION
Unlike the one in the deis helm chart, the service manifest for workflow included here describes a service that's unroutable.  This causes havoc for anyone using the router-- i.e. anyone who started from a stock helm install of Deis and now wants to hack on workflow and sideload their hacks into their existing cluster.  Making the service routable also causes no harm to anyone _not_ wishing to use the router.