### PR TITLE
bug(client): restore client proxy behavior

### DIFF
--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -21,6 +21,7 @@ func CreateHTTPClient(sslVerify bool) *http.Client {
 	tr := &http.Transport{
 		TLSClientConfig:   &tls.Config{InsecureSkipVerify: !sslVerify},
 		DisableKeepAlives: true,
+		Proxy:             http.ProxyFromEnvironment,
 	}
 	return &http.Client{Transport: tr}
 }


### PR DESCRIPTION
Tested via `mitmproxy` and:

```console
client [client-proxy]$ http_proxy=localhost:8080 ./deis ps -a rococo-vocalist
=== rococo-vocalist Processes
--- web:
web.1 up (v2)
web.2 up (v2)
web.3 up (v2)
web.4 up (v2)
web.5 up (v2)
```