### PR TITLE
ref(*): remove etcd now that all state is being handled by db/k8s

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,9 +5,6 @@ RUN apk add --update-cache curl bash openssl sudo && rm -rf /var/cache/apk/*
 
 # install etcdctl and confd
 RUN apk add --update-cache curl tar \
-    && curl -sSL https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz \
-    | tar -vxz -C /usr/local/bin --strip=1 etcd-v2.2.1-linux-amd64/etcdctl \
-    && chown root:root /usr/local/bin/etcdctl \
     && curl -sSL -o /usr/local/bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 \
     && chmod +x /usr/local/bin/confd \
     && apk del --purge curl tar \

--- a/rootfs/api/management/commands/load_db_state_to_k8s.py
+++ b/rootfs/api/management/commands/load_db_state_to_k8s.py
@@ -5,12 +5,12 @@ from api.models import Key, App, Domain, Certificate, Config
 
 class Command(BaseCommand):
     """Management command for publishing Deis platform state from the database
-    to etcd.
+    to k8s.
     """
     def handle(self, *args, **options):
         """Publishes Deis platform state from the database to etcd."""
-        print("Publishing DB state to etcd...")
+        print("Publishing DB state to k8s...")
         for model in (Key, App, Domain, Certificate, Config):
             for obj in model.objects.all():
                 obj.save()
-        print("Done Publishing DB state to etcd.")
+        print("Done Publishing DB state to k8s.")

--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -13,62 +13,11 @@ echo system information:
 echo "Django Version: $(./manage.py --version)"
 python --version
 
-# configure etcd
-export ETCD_PORT=${DEIS_ETCD_1_SERVICE_PORT_CLIENT:-4001}
-export ETCD_HOST=${DEIS_ETCD_1_SERVICE_HOST:-$HOST}
-export ETCD="$ETCD_HOST:$ETCD_PORT"
-export ETCD_PATH=${ETCD_PATH:-/deis/controller}
-export ETCD_TTL=${ETCD_TTL:-20}
+# spawn confd in the background to update services based on changes
+confd -backend env --confdir /app --log-level error --interval 5 &
 
-# wait for etcd to be available
-until etcdctl --no-sync -C "$ETCD" ls >/dev/null 2>&1; do
-	echo "waiting for etcd at $ETCD..."
-	sleep $((ETCD_TTL/2))  # sleep for half the TTL
-done
-
-function etcd_set_default {
-	set +e
-	ERROR="$(etcdctl --no-sync -C "$ETCD" mk "$ETCD_PATH/$1" "$2" 2>&1)"
-	if [[ $? -ne 0 ]] && echo "$ERROR" | grep -iqve "key already exists"; then
-		echo "etcd_set_default: an etcd error occurred ($ERROR)"
-		echo "aborting..."
-		exit 1
-	fi
-	set -e
-}
-
-function etcd_safe_mkdir {
-	set +e
-	ERROR="$(etcdctl --no-sync -C "$ETCD" mkdir "$1" 2>&1)"
-
-	if [[ $? -ne 0 ]] && echo "$ERROR" | grep -iqve "key already exists"; then
-		echo "etcd_safe_mkdir: an etcd error occurred ($ERROR)"
-		echo "aborting..."
-		exit 1
-	fi
-	set -e
-}
-
-etcd_set_default protocol "${DEIS_PROTOCOL:-http}"
-etcd_set_default registrationMode "enabled"
-etcd_set_default webEnabled 0
-
-# safely create required keyspaces
-etcd_safe_mkdir /deis/domains
-etcd_safe_mkdir /deis/platform
-etcd_safe_mkdir /deis/scheduler
-etcd_safe_mkdir /deis/services
-
-# wait for confd to run once and install initial templates
-until confd -onetime -node "$ETCD" --confdir /app --log-level error; do
-	echo "controller: waiting for confd to write initial templates..."
-	sleep $((ETCD_TTL/2))  # sleep for half the TTL
-done
-
-cd /app
-
-mkdir -p /data/logs
-chmod 777 /data/logs
+mkdir -p /app/data/logs
+chmod -R 777 /app/data/logs
 
 # allow deis user group permission to Docker socket
 if addgroup -g "$(stat -c "%g" /var/run/docker.sock)" docker; then
@@ -78,18 +27,18 @@ else
 fi
 
 echo "Django checks:"
-./manage.py check --deploy api
+python /app/manage.py check --deploy api
 
 echo "Health Checks:"
-./manage.py healthchecks
+python /app/manage.py healthchecks
 
 echo "Database Migrations:"
-sudo -E -u deis ./manage.py migrate --noinput
+sudo -E -u deis python /app/manage.py migrate --noinput
 
 # spawn a gunicorn server in the background
-sudo -E -u deis gunicorn -c deis/gconf.py deis.wsgi &
+sudo -E -u deis gunicorn -c /app/deis/gconf.py deis.wsgi &
 
-./manage.py load_db_state_to_etcd
+python /app/manage.py load_db_state_to_k8s
 
 # smart shutdown on SIGTERM (SIGINT is handled by gunicorn)
 function on_exit() {
@@ -99,9 +48,6 @@ function on_exit() {
 	exit 0
 }
 trap on_exit TERM
-
-# spawn confd in the background to update services based on etcd changes
-confd -node "$ETCD" --confdir /app --log-level error --interval 5 &
 
 echo deis-controller running...
 

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -248,10 +248,6 @@ LOGGING = {
 }
 TEST_RUNNER = 'api.tests.SilentDjangoTestSuiteRunner'
 
-# etcd settings
-ETCD_HOST = os.environ.get('DEIS_ETCD_1_SERVICE_HOST', '127.0.0.1')
-ETCD_PORT = os.environ.get('DEIS_ETCD_1_SERVICE_PORT_CLIENT', 4001)
-
 # default deis settings
 LOG_LINES = 100
 TEMPDIR = tempfile.mkdtemp(prefix='deis')
@@ -295,13 +291,6 @@ DATABASES = {
 }
 
 APP_URL_REGEX = '[a-z0-9-]+'
-
-# Unit Hostname handling.
-# Supports:
-#  default      - Docker generated hostname
-#  application  - Hostname based on application unit name (i.e. my-application.v2.web.1)
-#  server       - Hostname based on CoreOS server hostname
-UNIT_HOSTNAME = 'default'
 
 # Create a file named "local_settings.py" to contain sensitive settings data
 # such as database configuration, admin email, or passwords and keys. It

--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -10,7 +10,7 @@ jsonfield==1.0.3
 morph==0.1.2
 ndg-httpsclient==0.4.0
 psycopg2==2.6.1
-python-etcd==0.3.2
+PyOpenSSL==0.15.1
 PyYAML==3.11
 requests==2.9.1
 simpleflock==0.0.3

--- a/rootfs/templates/confd_settings.py
+++ b/rootfs/templates/confd_settings.py
@@ -16,6 +16,8 @@ SCHEDULER_URL = "https://{}:{}".format(
 
 {{ if exists "/deis/controller/registrationMode" }}
 REGISTRATION_MODE = '{{ getv "/deis/controller/registrationMode" }}'
+{{ else }}
+REGISTRATION_MODE = 'enabled'
 {{ end }}
 
 {{ if exists "/deis/controller/subdomain" }}


### PR DESCRIPTION
This switches `confd` to source in `env` var for `gunicorn` and a few other minor things, for now

Following items need to be figured out and #9 touches on some of that

* [x] etcd_set_default protocol "${DEIS_PROTOCOL:-http}"
* [x] etcd_set_default secretKey "${DEIS_SECRET_KEY:-$(openssl rand -base64 64 | tr -d '\n')}"
* [x] etcd_set_default builderKey "${DEIS_BUILDER_KEY:-$(openssl rand -base64 64 | tr -d '\n')}"
* [x] Builder reading app names, users and keys from an alternative location

Depends on #242 as it ditches one of the `etcd` requirement that is embedded in the models