### PR TITLE
fix(client): fix URLs used by deis open

### DIFF
--- a/client/controller/models/apps/apps.go
+++ b/client/controller/models/apps/apps.go
@@ -10,6 +10,8 @@ import (
 	"github.com/deis/workflow/client/controller/client"
 )
 
+const workflowURLPrefix = "deis."
+
 // List lists apps on a Deis controller.
 func List(c *client.Client, results int) ([]api.App, int, error) {
 	body, count, err := c.LimitedRequest("/v2/apps/", results)
@@ -25,7 +27,7 @@ func List(c *client.Client, results int) ([]api.App, int, error) {
 
 	for name, app := range apps {
 		// Add in app URL based on controller hostname, port included
-		app.URL = fmt.Sprintf("%s.%s", app.ID, c.ControllerURL.Host)
+		app.URL = fmt.Sprintf("%s.%s", app.ID, strings.TrimPrefix(c.ControllerURL.Host, workflowURLPrefix))
 		apps[name] = app
 	}
 
@@ -58,7 +60,7 @@ func New(c *client.Client, id string) (api.App, error) {
 	}
 
 	// Add in app URL based on controller hostname, port included
-	app.URL = fmt.Sprintf("%s.%s", app.ID, c.ControllerURL.Host)
+	app.URL = fmt.Sprintf("%s.%s", app.ID, strings.TrimPrefix(c.ControllerURL.Host, workflowURLPrefix))
 
 	return app, nil
 }
@@ -80,7 +82,7 @@ func Get(c *client.Client, appID string) (api.App, error) {
 	}
 
 	// Add in app URL based on controller hostname, port included
-	app.URL = fmt.Sprintf("%s.%s", app.ID, c.ControllerURL.Host)
+	app.URL = fmt.Sprintf("%s.%s", app.ID, strings.TrimPrefix(c.ControllerURL.Host, workflowURLPrefix))
 
 	return app, nil
 }


### PR DESCRIPTION
Fixes #111 for the average case where the controller URL begins with `deis.`.

Other edge cases are unaccounted for, but there's really no good way to accurately and _universally_ infer application URLs based on the controller URL since the controller URL really could be anything in v2.