### PR TITLE
feat(tags): implement tags as k8s node selectors

### DIFF
--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -274,6 +274,12 @@ class ConfigViewSet(ReleasableViewSet):
     model = models.Config
     serializer_class = serializers.ConfigSerializer
 
+    def create(self, request, **kwargs):
+        try:
+            return super(ConfigViewSet, self).create(request, **kwargs)
+        except EnvironmentError as e:
+            return Response({'detail': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
     def post_save(self, config):
         release = config.app.release_set.latest()
         self.release = release.new(self.request.user, config=config, build=release.build)

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -64,5 +64,11 @@ class MockSchedulerClient(AbstractSchedulerClient):
     def _update_service(self, namespace, name, data):
         pass
 
+    def _get_nodes(self, **kwargs):
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = b'{"items": [{"metadata": {"labels": {"env": "prod"}}}]}'
+        return resp
+
 
 SchedulerClient = MockSchedulerClient


### PR DESCRIPTION
Implement deis tags as k8s nodeSelector. Uses the /nodes API endpoint to verify if a label already exists or not. Multiple labels compound.

This is the first implementation of labelSelector and fieldSelector on a GET call. It will be ported to most of the GET functions eventually

Depends on #260
Fixes #168