### PR TITLE
ref(secrets): read generated secrets from k8s for the setings file

### DIFF
--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -50,8 +50,6 @@ function etcd_safe_mkdir {
 }
 
 etcd_set_default protocol "${DEIS_PROTOCOL:-http}"
-etcd_set_default secretKey "${DEIS_SECRET_KEY:-$(openssl rand -base64 64 | tr -d '\n')}"
-etcd_set_default builderKey "${DEIS_BUILDER_KEY:-$(openssl rand -base64 64 | tr -d '\n')}"
 etcd_set_default registrationMode "enabled"
 etcd_set_default webEnabled 0
 

--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -664,8 +664,10 @@ class KubeHTTPClient(AbstractSchedulerClient):
                 continue
             create = True
             rc = self._get_rc(name, app_name)
-            if ("observedGeneration" in rc["status"]
-                    and rc["metadata"]["generation"] == rc["status"]["observedGeneration"]):
+            if (
+                "observedGeneration" in rc["status"] and
+                rc["metadata"]["generation"] == rc["status"]["observedGeneration"]
+            ):
                 break
 
             time.sleep(1)

--- a/rootfs/templates/confd_settings.py
+++ b/rootfs/templates/confd_settings.py
@@ -1,8 +1,11 @@
 import os
 
 # security keys and auth tokens
-SECRET_KEY = '{{ getv "/deis/controller/secretKey" }}'
-BUILDER_KEY = '{{ getv "/deis/controller/builderKey" }}'
+with open('/var/run/secrets/api/builder/auth/builder-key') as f:
+    BUILDER_KEY = f.read()
+
+with open('/var/run/secrets/api/django/secret-key') as f:
+    SECRET_KEY = f.read()
 
 # scheduler settings
 SCHEDULER_MODULE = 'scheduler'


### PR DESCRIPTION
Not the biggest fan of reading it on every API request but we do have a very low yield API right now and we can somewhat rely on filesystem caches

Maybe later (stable timeframe or after stable) I can output it into the file statically or use confd + env vars like I did in #245 for other things

Fixes #9