### PR TITLE
chore(requirements.txt): update Django to 1.9.1

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -1,6 +1,6 @@
 # Deis controller requirements
 #
-Django==1.9
+Django==1.9.1
 django-cors-headers==1.1.0
 django-guardian==1.3.2
 djangorestframework==3.3.2


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.9/releases/1.9.1/. I tested with the workflow-e2e tests against the deis-dev `helm` chart.