### PR TITLE
chore(deploy.sh): Stop producing v2-beta images for each PR merge

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -5,7 +5,7 @@
 
 cd "$(dirname "$0")" || exit 1
 
-export IMAGE_PREFIX=deisci VERSION=v2-beta
+export VERSION=canary
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 DEIS_REGISTRY='' make -C .. docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io

--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -65,4 +65,3 @@ spec:
         - name: builder-key-auth
           secret:
             secretName: builder-key-auth
-


### PR DESCRIPTION
Instead we should produce a canary image. This allows us to cut stable release images while providing an image that tracks HEAD. This image should also be in the deis org.