### PR TITLE
ref(tests): since Django 1.7 tests are auto detected based on test*.py

### DIFF
--- a/rootfs/api/tests/__init__.py
+++ b/rootfs/api/tests/__init__.py
@@ -24,20 +24,3 @@ def mock_status_ok(*args, **kwargs):
 
 def mock_none(*args, **kwargs):
     return None
-
-from .test_api_middleware import *  # noqa
-from .test_app import *  # noqa
-from .test_auth import *  # noqa
-from .test_build import *  # noqa
-from .test_certificate import *  # noqa
-from .test_config import *  # noqa
-from .test_container import *  # noqa
-from .test_domain import *  # noqa
-from .test_healthcheck import *  # noqa
-from .test_hooks import *  # noqa
-from .test_key import *  # noqa
-from .test_limits import *  # noqa
-from .test_perm import *  # noqa
-from .test_release import *  # noqa
-from .test_scheduler import *  # noqa
-from .test_users import *  # noqa


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.7/topics/testing/overview/

When you run your tests, the default behavior of the test utility is to find all the test cases (that is, subclasses of unittest.TestCase) in any file whose name begins with test, automatically build a test suite out of those test cases, and run that suite.