### PR TITLE
ref(healthchecks): rename endpoint to /healthz

### DIFF
--- a/manifests/deis-workflow-rc.yml
+++ b/manifests/deis-workflow-rc.yml
@@ -19,13 +19,13 @@ spec:
           image: quay.io/deisci/workflow:v2-beta
           readinessProbe:
             httpGet:
-              path: /health-check
+              path: /healthz
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 1
           livenessProbe:
             httpGet:
-              path: /health-check
+              path: /healthz
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 1
@@ -65,4 +65,3 @@ spec:
         - name: builder-key-auth
           secret:
             secretName: builder-key-auth
-

--- a/rootfs/api/tests/test_healthcheck.py
+++ b/rootfs/api/tests/test_healthcheck.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 class HealthCheckTest(TestCase):
 
     def setUp(self):
-        self.url = '/health-check'
+        self.url = '/healthz'
 
     def test_healthcheck(self):
         # GET and HEAD (no auth required)

--- a/rootfs/deis/urls.py
+++ b/rootfs/deis/urls.py
@@ -10,6 +10,6 @@ from django.conf.urls import include, url
 from api.views import HealthCheckView
 
 urlpatterns = [
-    url(r'^health-check$', HealthCheckView.as_view()),
+    url(r'^healthz$', HealthCheckView.as_view()),
     url(r'^v2/', include('api.urls')),
 ]


### PR DESCRIPTION
`/healthz` is a more standard endpoint name for k8s healthchecks. See also deis/charts#76.