### PR TITLE
feat(workflow): log the template used in case of an error

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -663,6 +663,7 @@ class KubeHTTPClient(AbstractSchedulerClient):
         if unhealthy(resp.status_code):
             error(resp, 'create ReplicationController "{}" in Namespace "{}"',
                   name, app_name)
+            logger.debug('template used: {}'.format(json.dumps(js_template, indent=4)))
 
         create = False
         for _ in range(30):


### PR DESCRIPTION
Without some info about the error is not possible to know where to look
Example without the log:
```
ERROR srv-f22: srv-f22_v1046.web (deploy): failed to create ReplicationController "srv-f22-v1046-web" in Namespace "srv-f22": 400 Bad Request
{'apiVersion': 'v1', 'metadata': {}, 'kind': 'Status', 'status': 'Failure', 'message': 'ReplicationController in version v1 cannot be handled as a ReplicationController: [pos 1053]: json: expect char \'"\' but got char \'6\'', 'code': 400, 'reason': 'BadRequest'}
```