### PR TITLE
ref(workflow): the value of any key in env must be a string

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -640,7 +640,7 @@ class KubeHTTPClient(AbstractSchedulerClient):
 
         if env:
             for k, v in env.items():
-                containers[0]["env"].append({"name": k, "value": v})
+                containers[0]["env"].append({"name": k, "value": str(v)})
 
         if mem or cpu:
             containers[0]["resources"] = {"limits": {}}


### PR DESCRIPTION
This is related to the error in #297 where one value was a number
```
          }, {
            "name": "DOCKERIMAGE",
            "value": "1"
          }, {
            "name": "NODE_ENV",
            "value": "production"
          }, {
            "name": "REDIS_PORT",
            "value": 6381
          }, {
            "name": "REDIS_HOST",
            "value": "192.168.2.2"
          }],
```