### PR TITLE
fix(secrets): strip whitespaces / newlines from k8s secrets when reading the files

### DIFF
--- a/rootfs/templates/confd_settings.py
+++ b/rootfs/templates/confd_settings.py
@@ -2,10 +2,10 @@ import os
 
 # security keys and auth tokens
 with open('/var/run/secrets/api/builder/auth/builder-key') as f:
-    BUILDER_KEY = f.read()
+    BUILDER_KEY = f.read().strip()
 
 with open('/var/run/secrets/api/django/secret-key') as f:
-    SECRET_KEY = f.read()
+    SECRET_KEY = f.read().strip()
 
 # scheduler settings
 SCHEDULER_MODULE = 'scheduler'


### PR DESCRIPTION
Relates to deis/builder#116

This only helps if we are reading it from the files, in future versions we'll get those values directly via ENV and we may not be able to strip it ahead of time.

/cc @aledbf @arschles 