### PR TITLE
chore(requirements.txt): update mkdocs to 0.15.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs==0.14.0
+mkdocs==0.15.0
 markdown-checklist==0.4.1


### PR DESCRIPTION
Adds official support for Python 3.5, among other things.
See http://www.mkdocs.org/about/release-notes/#version-0150-2016-01-21

I've tested this locally with Mac OS X python 3.5.1 from Homebrew.