### PR TITLE
fix(docs): use extra_javascript to fix navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -81,4 +81,8 @@ markdown_extensions:
   - markdown_checklist.extension
   - admonition
   - codehilite
+extra_javascript:
+  - static/js/adjustments.js
+  - static/js/bootstrap.min.js
+  - static/js/checkURL.js
 google_analytics: ['UA-42867143-1', 'deis.io']


### PR DESCRIPTION
Some JS files required for the right-hand nav bar weren't being loaded, so top-level `l1` nav was failing.

TESTING: install the python `docs/requirements.txt` using Python 3.5, then `cd docs/ && make build && mkdocs serve`. Then open a browser to http://127.0.0.1:8000/ and enjoy a functional right-hand navigation bar.