### PR TITLE
chore(requirements.txt): update django-guardian to 1.4.1

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -2,7 +2,7 @@
 #
 Django==1.9.1
 django-cors-headers==1.1.0
-django-guardian==1.3.2
+django-guardian==1.4.1
 djangorestframework==3.3.2
 jsonfield==1.0.3
 docker-py==1.6.0


### PR DESCRIPTION
See https://raw.githubusercontent.com/django-guardian/django-guardian/devel/CHANGES. In particular, django-guardian/django-guardian#366 was fixed which seems possible to occur in Deis' PostgreSQL setup at first glance.

I tested this with the deis-dev chart on [kube-solo-osx](https://github.com/TheNewNormal/kube-solo-osx).