### PR TITLE
Check

### DIFF
--- a/rootfs/bin/boot
+++ b/rootfs/bin/boot
@@ -77,6 +77,9 @@ else
 	addgroup deis "$(stat -c "%G" /var/run/docker.sock)"
 fi
 
+echo "Django checks:"
+./manage.py check --deploy api
+
 echo "Health Checks:"
 ./manage.py healthchecks
 

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -13,6 +13,13 @@ PROJECT_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 
 DEBUG = False
 
+# Silence two security messages around SSL as router takes care of them
+# https://docs.djangoproject.com/es/1.9/ref/checks/#security
+SILENCED_SYSTEM_CHECKS = [
+    'security.W004',
+    'security.W008'
+]
+
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
 )
@@ -84,14 +91,14 @@ TEMPLATES = [
 MIDDLEWARE_CLASSES = (
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'api.middleware.APIVersionMiddleware',
     'deis.middleware.PlatformVersionMiddleware',
-    # Uncomment the next line for simple clickjacking protection:
-    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
 ROOT_URLCONF = 'deis.urls'
@@ -125,8 +132,8 @@ ANONYMOUS_USER_ID = -1
 LOGIN_URL = '/v2/auth/login/'
 LOGIN_REDIRECT_URL = '/'
 
+# Security settings
 CORS_ORIGIN_ALLOW_ALL = True
-
 CORS_ALLOW_HEADERS = (
     'content-type',
     'accept',
@@ -140,6 +147,17 @@ CORS_EXPOSE_HEADERS = (
     'DEIS_PLATFORM_VERSION',
     'Deis-Release',
 )
+
+X_FRAME_OPTIONS = 'DENY'
+CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+
+# Honor HTTPS from a trusted proxy
+# see https://docs.djangoproject.com/en/1.6/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # standard datetime format used for logging, model timestamps, etc.
 DEIS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%Z'
@@ -262,8 +280,9 @@ SCHEDULER_AUTH = None
 SCHEDULER_OPTIONS = None
 
 # security keys and auth tokens
-SECRET_KEY = os.environ.get('DEIS_SECRET_KEY', 'CHANGEME_sapm$s%upvsw5l_zuy_&29rkywd^78ff(qi')
-BUILDER_KEY = os.environ.get('DEIS_BUILDER_KEY', 'CHANGEME_sapm$s%upvsw5l_zuy_&29rkywd^78ff(qi')
+random_secret = 'CHANGEME_sapm$s%upvsw5l_zuy_&29rkywd^78ff(qi*#@&*^'
+SECRET_KEY = os.environ.get('DEIS_SECRET_KEY', random_secret)
+BUILDER_KEY = os.environ.get('DEIS_BUILDER_KEY', random_secret)
 
 # registry settings
 REGISTRY_HOST = os.environ.get('DEIS_REGISTRY_SERVICE_HOST', '127.0.0.1')
@@ -298,10 +317,6 @@ DATABASES = {
 }
 
 APP_URL_REGEX = '[a-z0-9-]+'
-
-# Honor HTTPS from a trusted proxy
-# see https://docs.djangoproject.com/en/1.6/ref/settings/#secure-proxy-ssl-header
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Unit Hostname handling.
 # Supports:


### PR DESCRIPTION
Started out with these

```
System check identified some issues:

WARNINGS:
?: (security.W002) You do not have 'django.middleware.clickjacking.XFrameOptionsMiddleware' in your MIDDLEWARE_CLASSES, so your pages will not be served with an 'x-frame-options' header. Unless there is a good reason for your site to be served in a frame, you should consider enabling this header to help prevent clickjacking attacks.
?: (security.W003) You don't appear to be using Django's built-in cross-site request forgery protection via the middleware ('django.middleware.csrf.CsrfViewMiddleware' is not in your MIDDLEWARE_CLASSES). Enabling the middleware is the safest approach to ensure you don't leave any holes.
?: (security.W004) You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
?: (security.W006) Your SECURE_CONTENT_TYPE_NOSNIFF setting is not set to True, so your pages will not be served with an 'x-content-type-options: nosniff' header. You should consider enabling this header to prevent the browser from identifying content types incorrectly.
?: (security.W007) Your SECURE_BROWSER_XSS_FILTER setting is not set to True, so your pages will not be served with an 'x-xss-protection: 1; mode=block' header. You should consider enabling this header to activate the browser's XSS filtering and help prevent XSS attacks.
?: (security.W008) Your SECURE_SSL_REDIRECT setting is not set to True. Unless your site should be available over both SSL and non-SSL connections, you may want to either set this setting True or configure a load balancer or reverse-proxy server to redirect all connections to HTTPS.
?: (security.W009) Your SECRET_KEY has less than 50 characters or less than 5 unique characters. Please generate a long and random SECRET_KEY, otherwise many of Django's security-critical features will be vulnerable to attack.
?: (security.W012) SESSION_COOKIE_SECURE is not set to True. Using a secure-only session cookie makes it more difficult for network traffic sniffers to hijack user sessions.
```

Running that on boot should help us (and anyone extending workflow) to catch bad django problems