### PR TITLE
fix(controller): do not require slash at the end of `GET /v2/users`

### DIFF
--- a/rootfs/api/tests/test_users.py
+++ b/rootfs/api/tests/test_users.py
@@ -11,23 +11,20 @@ class TestUsers(TestCase):
     fixtures = ['tests.json']
 
     def test_super_user_can_list(self):
-        url = '/v2/users'
-
         user = User.objects.get(username='autotest')
         token = Token.objects.get(user=user)
 
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(token))
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['results']), 3)
+        for url in ['/v2/users', '/v2/users/']:
+            response = self.client.get(url,
+                                       HTTP_AUTHORIZATION='token {}'.format(token))
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.data['results']), 3)
 
     def test_non_super_user_cannot_list(self):
-        url = '/v2/users'
-
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user)
 
-        response = self.client.get(url,
-                                   HTTP_AUTHORIZATION='token {}'.format(token))
-        self.assertEqual(response.status_code, 403)
+        for url in ['/v2/users', '/v2/users/']:
+            response = self.client.get(url,
+                                       HTTP_AUTHORIZATION='token {}'.format(token))
+            self.assertEqual(response.status_code, 403)

--- a/rootfs/api/tests/test_users.py
+++ b/rootfs/api/tests/test_users.py
@@ -11,7 +11,7 @@ class TestUsers(TestCase):
     fixtures = ['tests.json']
 
     def test_super_user_can_list(self):
-        url = '/v2/users/'
+        url = '/v2/users'
 
         user = User.objects.get(username='autotest')
         token = Token.objects.get(user=user)
@@ -23,7 +23,7 @@ class TestUsers(TestCase):
         self.assertEqual(len(response.data['results']), 3)
 
     def test_non_super_user_cannot_list(self):
-        url = '/v2/users/'
+        url = '/v2/users'
 
         user = User.objects.get(username='autotest2')
         token = Token.objects.get(user=user)

--- a/rootfs/api/urls.py
+++ b/rootfs/api/urls.py
@@ -103,5 +103,5 @@ urlpatterns = [
     url(r'^certs/?',
         views.CertificateViewSet.as_view({'get': 'list', 'post': 'create'})),
     # list users
-    url(r'^users/', views.UserView.as_view({'get': 'list'})),
+    url(r'^users/?', views.UserView.as_view({'get': 'list'})),
 ]


### PR DESCRIPTION
This ports the fix from deis/deis#4898 to Deis v2 workflow. 

I updated the URL to `/v2/` here relative to the original PR.  Thanks again to @smt116, let me know if you have any concerns or comments.

Closes #333.