### PR TITLE
feat(builder hooks): app and user hooks for builder to get public keys

### DIFF
--- a/rootfs/api/tests/test_key.py
+++ b/rootfs/api/tests/test_key.py
@@ -71,14 +71,17 @@ class KeyTest(TestCase):
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 201)
         key_id = response.data['id']
+
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
+
         url = '/v2/keys/{key_id}'.format(**locals())
         response = self.client.get(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(body['id'], response.data['id'])
         self.assertEqual(body['public'], response.data['public'])
+
         response = self.client.delete(url, HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 204)
 

--- a/rootfs/api/urls.py
+++ b/rootfs/api/urls.py
@@ -72,6 +72,10 @@ urlpatterns = [
     url(r'^keys/?',
         views.KeyViewSet.as_view({'get': 'list', 'post': 'create'})),
     # hooks
+    url(r'^hooks/keys/(?P<id>{})/(?P<username>[-_\w]+)?'.format(settings.APP_URL_REGEX),
+        views.KeyHookViewSet.as_view({'get': 'users'})),
+    url(r'^hooks/keys/(?P<id>{})/?'.format(settings.APP_URL_REGEX),
+        views.KeyHookViewSet.as_view({'get': 'app'})),
     url(r'^hooks/push/?',
         views.PushHookViewSet.as_view({'post': 'create'})),
     url(r'^hooks/build/?',


### PR DESCRIPTION
Give builder the ability to query for application or application + user and get the public key associated if both resource exist.
Replaces etcd usage for builder.

Fixes #335