### PR TITLE
fix(Makefile): Restore local build/install capability

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -30,10 +30,13 @@ glideup:
 	${DEV_ENV_CMD} glide up
 
 build:
-	${DEV_ENV_CMD} go build -a -installsuffix cgo -ldflags '-s' -o deis .
+	${DEV_ENV_CMD} make binary-build
 	@$(call check-static-binary,deis)
 
-install: build
+binary-build:
+	go build -a -installsuffix cgo -ldflags '-s' -o deis .
+
+install:
 	cp deis $$GOPATH/bin
 
 installer: build


### PR DESCRIPTION
I am a big fan of #340 (because I am a fan in general of containerizing our builds), but it had the unfortunate side-effect of removing any possibility of building the client from source on a Mac and then _using_ that client on a Mac-- this is something I do frequently and I suspect I'm not the only one.

This PR restores that possibility through:

```
$ make binary-build install
```