### PR TITLE
fix(logger): Try not to fail so hard when issuing deis logs command

### DIFF
--- a/client/controller/models/apps/apps.go
+++ b/client/controller/models/apps/apps.go
@@ -97,15 +97,12 @@ func Logs(c *client.Client, appID string, lines int) (string, error) {
 
 	body, err := c.BasicRequest("GET", u, nil)
 
-	if err != nil {
-		return fmt.Sprintf("Error:%v", err), err
-	}
-
-	if len(body) < 1 {
+	if err != nil || len(body) < 1 {
 		return fmt.Sprintf(
 			`There are currently no log messages. Please check the following things:
 1) Logger and fluentd pods are running.
-2) The application is writing logs to the logger component.
+2) If you just installed the logger components via the chart, please make sure you restarted the workflow pod.
+3) The application is writing logs to the logger component.
 You can verify that logs are appearing in the logger component by issuing the following command:
 curl http://<log service ip>:8088/%s on a kubernetes host.
 To get the service ip you can do the following: kubectl get svc deis-logger --namespace=deis`, appID), nil


### PR DESCRIPTION
fixes #267
This fix provides a better error message when an error code or len(body) < 1 is returned from the workflow api.