### PR TITLE
chore(scheduler): remove second param in get() call as it is redundant

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -606,7 +606,7 @@ class KubeHTTPClient(AbstractSchedulerClient):
 
         # Check if it is a slug builder image.
         # Example format: golden-earrings:git-5450cbcdaaf9afe6fadd219c94ac9c449bd62413s
-        if kwargs.get('build_type', {}) == "buildpack":
+        if kwargs.get('build_type') == "buildpack":
             imgurl = 'http://{}/git/home/{}/push/slug.tgz'.format(
                 settings.S3EP,
                 image)


### PR DESCRIPTION
Fixes #353