### PR TITLE
fix(auth): return a 409 if a user is cancelled that has apps

### DIFF
--- a/client/cmd/auth.go
+++ b/client/cmd/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"syscall"
 
@@ -241,8 +242,11 @@ func Cancel(username string, password string, yes bool) error {
 	}
 
 	err = auth.Delete(c, username)
-
-	if err != nil {
+	cleanup := fmt.Errorf("\n%s %s\n\n", "409", "Conflict")
+	if reflect.DeepEqual(err, cleanup) {
+		fmt.Printf("%s still has application associated with it. Transfer ownership or delete them first\n", username)
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/client/controller/models/auth/auth_test.go
+++ b/client/controller/models/auth/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/deis/workflow/client/controller/client"
@@ -18,6 +19,7 @@ const passwdExpected string = `{"username":"test","password":"old","new_password
 const regenAllExpected string = `{"all":true}`
 const regenUserExpected string = `{"username":"test"}`
 const cancelUserExpected string = `{"username":"foo"}`
+const cancelAdminExpected string = `{"username":"admin"}`
 
 type fakeHTTPServer struct {
 	regenBodyEmpty    bool
@@ -131,7 +133,12 @@ func (f *fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			res.Write(nil)
 		}
 
-		if string(body) == cancelUserExpected && !f.cancelUsername {
+		if string(body) == cancelAdminExpected && !f.cancelUsername {
+			f.cancelUsername = true
+			res.WriteHeader(http.StatusConflict)
+			res.Write(nil)
+			return
+		} else if string(body) == cancelUserExpected && !f.cancelUsername {
 			f.cancelUsername = true
 			res.WriteHeader(http.StatusNoContent)
 			res.Write(nil)
@@ -248,6 +255,31 @@ func TestDelete(t *testing.T) {
 
 	if err := Delete(&client, ""); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestDeleteUserApp(t *testing.T) {
+	t.Parallel()
+
+	handler := fakeHTTPServer{cancelUsername: false, cancelEmpty: false}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpClient := client.CreateHTTPClient(false)
+	client := client.Client{HTTPClient: httpClient, ControllerURL: *u}
+
+	err = Delete(&client, "admin")
+	// should be a 409 Conflict
+
+	expected := fmt.Errorf("\n%s %s\n\n", "409", "Conflict")
+	if reflect.DeepEqual(err, expected) == false {
+		t.Errorf("got '%s' but expected '%s'", err, expected)
 	}
 }
 

--- a/rootfs/api/tests/test_auth.py
+++ b/rootfs/api/tests/test_auth.py
@@ -221,6 +221,20 @@ class AuthTest(TestCase):
                                       HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
         self.assertEqual(response.status_code, 204)
 
+        # user can not be deleted if it has an app attached to it
+        response = self.client.post(
+            '/v2/apps',
+            HTTP_AUTHORIZATION='token {}'.format(self.admin_token)
+        )
+        self.assertEqual(response.status_code, 201)
+        app_id = response.data['id']  # noqa
+        self.assertIn('id', response.data)
+
+        response = self.client.delete(url, json.dumps({'username': str(self.admin)}),
+                                      content_type='application/json',
+                                      HTTP_AUTHORIZATION='token {}'.format(self.admin_token))
+        self.assertEqual(response.status_code, 409)
+
     def test_passwd(self):
         """Test that a registered user can change the password."""
         # test registration workflow

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -77,6 +77,11 @@ class UserManagementViewSet(GenericViewSet):
             else:
                 raise PermissionDenied()
 
+        # A user can not be removed without apps changing ownership first
+        if len(models.App.objects.filter(owner=target_obj)) > 0:
+            msg = '{} still has applications assigned. Delete or transfer ownership'.format(str(target_obj))  # noqa
+            return Response({'detail': msg}, status=status.HTTP_409_CONFLICT)
+
         target_obj.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
```
deis auth:cancel --username=slack
cancel account slack at http://deis.172.17.8.100.xip.io? (y/N): y
Error:
409 Conflict
detail: slack still has applications assigned. Delete or transfer ownership
```

Can't do anything about the `Error` info there until we refactor the client