### PR TITLE
fix(local_settings.py): read DATABASES from settings.py

### DIFF
--- a/rootfs/conf.d/local_settings.toml
+++ b/rootfs/conf.d/local_settings.toml
@@ -1,6 +1,6 @@
 [template]
-src   = "confd_settings.py"
-dest  = "/templates/confd_settings.py"
+src   = "local_settings.py"
+dest  = "/app/deis/local_settings.py"
 uid = 1000
 gid = 1000
 mode  = "0640"

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -5,7 +5,6 @@ Django settings for the Deis project.
 import os.path
 import random
 import string
-import sys
 import tempfile
 
 # A boolean that turns on/off debug mode.
@@ -301,9 +300,3 @@ try:
     from .local_settings import *  # noqa
 except ImportError:
     pass
-
-# have confd_settings within container execution override all others
-# including local_settings (which may end up in the container)
-if os.path.exists('/templates/confd_settings.py'):
-    sys.path.append('/templates')
-    from confd_settings import *  # noqa

--- a/rootfs/templates/local_settings.py
+++ b/rootfs/templates/local_settings.py
@@ -1,5 +1,7 @@
 import os
 
+from .settings import *
+
 # security keys and auth tokens
 with open('/var/run/secrets/api/builder/auth/builder-key') as f:
     BUILDER_KEY = f.read().strip()


### PR DESCRIPTION
This fix renames and moves confd_settings.py to local_settings.py
within the container. This allows us to import the generic settings.py
and overwrite existing values, allowing the database settings to be
overwritten.