### PR TITLE
fix(local_settings): infer database name from username

### DIFF
--- a/rootfs/templates/local_settings.py
+++ b/rootfs/templates/local_settings.py
@@ -15,6 +15,8 @@ with open('/var/run/secrets/deis/database/creds/user') as f:
 with open('/var/run/secrets/deis/database/creds/password') as f:
     DATABASES['default']['PASSWORD'] = f.read().strip()
 
+DATABASES['default']['NAME'] = DATABASES['default']['USER']
+
 # scheduler settings
 SCHEDULER_MODULE = 'scheduler'
 SCHEDULER_URL = "https://{}:{}".format(


### PR DESCRIPTION
deis/postgres now creates the database name from the username.

See https://github.com/deis/postgres/blob/master/rootfs/docker-entrypoint.sh#L62