### PR TITLE
fix(logger): Return non-zero exit code when deis logs fails

### DIFF
--- a/client/controller/models/apps/apps.go
+++ b/client/controller/models/apps/apps.go
@@ -98,14 +98,14 @@ func Logs(c *client.Client, appID string, lines int) (string, error) {
 	body, err := c.BasicRequest("GET", u, nil)
 
 	if err != nil || len(body) < 1 {
-		return fmt.Sprintf(
+		return "", fmt.Errorf(
 			`There are currently no log messages. Please check the following things:
 1) Logger and fluentd pods are running.
 2) If you just installed the logger components via the chart, please make sure you restarted the workflow pod.
 3) The application is writing logs to the logger component.
 You can verify that logs are appearing in the logger component by issuing the following command:
 curl http://<log service ip>:8088/logs/%s on a kubernetes host.
-To get the service ip you can do the following: kubectl get svc deis-logger --namespace=deis`, appID), nil
+To get the service ip you can do the following: kubectl get svc deis-logger --namespace=deis`, appID)
 	}
 
 	// We need to trim a few characters off the front and end of the string


### PR DESCRIPTION
fixes #401
Create a user friendly error message and return that instead of a string.