### PR TITLE
chore(client): bump go-dev to 0.8.0 for glide 0.9.0

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/workflow/client
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.7.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.8.0
 DEV_ENV_WORK_DIR := /go/src/${repo_path}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
Help speed up the build a bit with newer Glide.