### PR TITLE
fix(client): exit 1 with malformed config:set input

### DIFF
--- a/client/cmd/config.go
+++ b/client/cmd/config.go
@@ -238,6 +238,7 @@ func parseConfig(configVars []string) map[string]interface{} {
 			configMap[captures[1]] = captures[2]
 		} else {
 			fmt.Printf("'%s' does not match the pattern 'key=var', ex: MODE=test\n", config)
+			os.Exit(1)
 		}
 	}
 

--- a/client/cmd/config_test.go
+++ b/client/cmd/config_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// Fancy way for testing processes exit unsuccessfully.
+// See https://talks.golang.org/2014/testing.slide#23
+func TestParseConfig(t *testing.T) {
+	if os.Getenv("TEST_BAD_CONFIG") == "1" {
+		parseConfig([]string{"FOO=bar", "CAR star"})
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestParseConfig")
+	cmd.Env = append(os.Environ(), "TEST_BAD_CONFIG=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+}


### PR DESCRIPTION
closes #228