### PR TITLE
fix(git): strip controller port when parsing git remotes

### DIFF
--- a/client/pkg/git/git.go
+++ b/client/pkg/git/git.go
@@ -93,6 +93,9 @@ func findRemote(host string) (string, error) {
 
 	cmd := string(out)
 
+	// Strip off any trailing :port number after the host name.
+	host = strings.Split(host, ":")[0]
+
 	for _, line := range strings.Split(cmd, "\n") {
 		for _, remote := range strings.Split(line, " ") {
 			if strings.Contains(remote, host) {


### PR DESCRIPTION
When doing any `deis apps:` command, the CLI would fail to detect the app name from the `git` remote if the workflow controller URL includes a port. The `findRemote` function was searching for "deis.192.168.64.2.xip.io:31713" (for example) in output like this:
```console
$ git remote -v
deis	ssh://git@deis.192.168.64.2.xip.io:2222/blurry-doghouse.git (fetch)
deis	ssh://git@deis.192.168.64.2.xip.io:2222/blurry-doghouse.git (push)
origin	https://github.com/deis/example-go (fetch)
origin	https://github.com/mboersma/example-go (push)
```

Closes #419. See also #280.