### PR TITLE
fix(cmd/apps): simplify URL prefixing

### DIFF
--- a/client/cmd/apps.go
+++ b/client/cmd/apps.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -142,15 +141,12 @@ func AppOpen(appID string) error {
 		return err
 	}
 
-	u, err := url.Parse(app.URL)
-
-	if err != nil {
-		return err
+	u := app.URL
+	if !(strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")) {
+		u = "http://" + u
 	}
 
-	u.Scheme = "http"
-
-	return webbrowser.Webbrowser(u.String())
+	return webbrowser.Webbrowser(u)
 }
 
 // AppLogs returns the logs from an app.


### PR DESCRIPTION
Go's net/url package returns malformed urls when a port is specified to `url.Parse()`.

For example, given "kiddie-armchair.192.168.64.2.xip.io:31258", `deis open` would call this `AppOpen` func and open a browser to "http:31258". The code appears to intend just to ensure a URL scheme prefix, so string manipulation should be adequate.