### PR TITLE
chore(dev_reqs): pin coverage and update flake8

### DIFF
--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -2,4 +2,4 @@
 coverage==4.0.3
 
 # Run "make flake8" to check python syntax and style
-flake8==2.5.1
+flake8==2.5.4

--- a/rootfs/dev_requirements.txt
+++ b/rootfs/dev_requirements.txt
@@ -1,5 +1,5 @@
 # Run "make coverage" or "make test-unit" for the % of code exercised during tests
-coverage>=4.0
+coverage==4.0.3
 
 # Run "make flake8" to check python syntax and style
 flake8==2.5.1


### PR DESCRIPTION
Pins the python `coverage` tool at 4.0.3 and updates `flake8` to 2.5.4.

See https://gitlab.com/pycqa/flake8/blob/master/CHANGES.rst