### PR TITLE
fix(scale): add more state information to make scale smarter

### DIFF
--- a/rootfs/scheduler/states.py
+++ b/rootfs/scheduler/states.py
@@ -13,8 +13,10 @@ class TransitionError(Exception):
 class JobState(enum.Enum):
     initialized = 1
     created = 2
-    up = 3
-    down = 4
-    destroyed = 5
-    crashed = 6
-    error = 7
+    starting = 3
+    up = 4
+    terminating = 5
+    down = 6
+    destroyed = 7
+    crashed = 8
+    error = 9


### PR DESCRIPTION
New states are

- starting
- terminating

These are the following main states that encompass a Pod in phase Running

### starting
k8s `state[Phase] == 'Running'` but container states are still not ready (probes and status itself on the container)

### running (called up in `ps:list`)
k8s `state[Phase] == 'Running'` but container states are ready and container status is "running"

### terminating
k8s `state[Phase] == 'Running'` but container states are not ready (due to termination) and container status is "terminating"

Fixes #430