### PR TITLE
fix(requirements): pull in the the fix branch of cryptography until official release happens

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -15,3 +15,4 @@ pytz==2015.7
 PyYAML==3.11
 requests==2.9.1
 simpleflock==0.0.3
+git+https://github.com/pyca/cryptography.git@1.2.x#egg=cryptography


### PR DESCRIPTION
OpenSSL 1.0.2g introduces some CVE fixes but also broke basic APIs and that broke pypi cryptography. We can not pin to a lower openssl on Alpine either