### PR TITLE
fix(views): return a 404 when trying to query on an object that does not exist

### DIFF
--- a/rootfs/api/tests/test_domain.py
+++ b/rootfs/api/tests/test_domain.py
@@ -109,6 +109,16 @@ class DomainTest(TestCase):
             )
             self.assertEqual(0, response.data['count'], msg)
 
+    def test_delete_domain_does_not_exist(self):
+        """Remove a domain that does not exist"""
+        url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)
+
+        url = '/v2/apps/{app_id}/domains/{domain}'.format(domain='test-domain.example.com',
+                                                          app_id=self.app_id)
+        response = self.client.delete(url, content_type='application/json',
+                                      HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 404)
+
     def test_delete_domain_does_not_remove_latest(self):
         """https://github.com/deis/deis/issues/3239"""
         url = '/v2/apps/{app_id}/domains'.format(app_id=self.app_id)

--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -330,7 +330,7 @@ class ContainerViewSet(AppResourceViewSet):
 
     def get_object(self, **kwargs):
         qs = self.get_queryset(**kwargs)
-        return qs.get(num=self.kwargs['num'])
+        return get_object_or_404(qs, num=self.kwargs['num'])
 
     def restart(self, *args, **kwargs):
         try:
@@ -378,7 +378,7 @@ class DomainViewSet(AppResourceViewSet):
 
     def get_object(self, **kwargs):
         qs = self.get_queryset(**kwargs)
-        return qs.get(domain=self.kwargs['domain'])
+        return get_object_or_404(qs, domain=self.kwargs['domain'])
 
 
 class CertificateViewSet(BaseDeisViewSet):
@@ -389,7 +389,7 @@ class CertificateViewSet(BaseDeisViewSet):
     def get_object(self, **kwargs):
         """Retrieve domain certificate by its name"""
         qs = self.get_queryset(**kwargs)
-        return qs.get(name=self.kwargs['name'])
+        return get_object_or_404(qs, name=self.kwargs['name'])
 
     def attach(self, request, *args, **kwargs):
         try:
@@ -430,7 +430,8 @@ class ReleaseViewSet(AppResourceViewSet):
 
     def get_object(self, **kwargs):
         """Get release by version always"""
-        return self.get_queryset(**kwargs).get(version=self.kwargs['version'])
+        qs = self.get_queryset(**kwargs)
+        return get_object_or_404(qs, version=self.kwargs['version'])
 
     def rollback(self, request, **kwargs):
         """


### PR DESCRIPTION
Affects trying to remove certificates, domains and other items via DELETE or updating via POST / PUT

Fixes #440