### PR TITLE
fix(pagination): use the proper limit pagination style from DRF

### DIFF
--- a/client/controller/client/http.go
+++ b/client/controller/client/http.go
@@ -69,7 +69,7 @@ func (c Client) Request(method string, path string, body []byte) (*http.Response
 
 // LimitedRequest allows limiting the number of responses in a request.
 func (c Client) LimitedRequest(path string, results int) (string, int, error) {
-	body, err := c.BasicRequest("GET", path+"?page_size="+strconv.Itoa(results), nil)
+	body, err := c.BasicRequest("GET", path+"?limit="+strconv.Itoa(results), nil)
 
 	if err != nil {
 		return "", -1, err

--- a/client/controller/client/http_test.go
+++ b/client/controller/client/http_test.go
@@ -47,7 +47,7 @@ func (fakeHTTPServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if req.URL.Path == "/limited/" && req.Method == "GET" && req.URL.RawQuery == "page_size=2" {
+	if req.URL.Path == "/limited/" && req.Method == "GET" && req.URL.RawQuery == "limit=2" {
 		res.Write([]byte(limitedFixture))
 		return
 	}

--- a/rootfs/deis/settings.py
+++ b/rootfs/deis/settings.py
@@ -159,7 +159,7 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }


### PR DESCRIPTION
Moved us to using limit instead of page_size so we didn't have to subclass things
http://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination

Fixes #463