### PR TITLE
fix(make): determine host OS for supplying to (container-ized) go build

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -3,9 +3,16 @@ export GO15VENDOREXPERIMENT=1
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/workflow/client
 
+HOST_OS := $(shell uname)
+ifeq ($(HOST_OS),Darwin)
+	GOOS=darwin
+else
+	GOOS=linux
+endif
+
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.0
 DEV_ENV_WORK_DIR := /go/src/${repo_path}
-DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
+DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=0 -e GOOS=${GOOS} -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 DIST_DIR := _dist
 


### PR DESCRIPTION
In #456 with a slight re-arrangement in client's Makefile, `go build`, being container-ized, was defaulting to producing a linux binary.  We now need to pass in host OS for building on darwin cc @mboersma  