### PR TITLE
ref(scheduler): create base k8s resources on app creation and update them during deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL_SCRIPTS = $(wildcard rootfs/bin/*) $(shell find "rootfs" -name '*.sh') $(w
 
 # Get the component informtation to a tmp location and get replica count
 $(shell kubectl get rc deis-$(COMPONENT) --namespace deis -o yaml > /tmp/deis-$(COMPONENT))
-DESIRED_REPLICAS=$(shell kubectl get -o template rc/deis-$(COMPONENT) --template={{.status.replicas}})
+DESIRED_REPLICAS=$(shell kubectl get -o template rc/deis-$(COMPONENT) --template={{.status.replicas}} --namespace deis)
 
 info:
 	@echo "Build tag:  ${VERSION}"

--- a/rootfs/api/tests/test_domain.py
+++ b/rootfs/api/tests/test_domain.py
@@ -87,8 +87,8 @@ class DomainTest(TestCase):
                 content_type='application/json',
                 HTTP_AUTHORIZATION='token {}'.format(self.token)
             )
-            result = response.data['results'][0]
-            self.assertEqual(domain, result['domain'], msg)
+            expected = [data['domain'] for data in response.data['results']]
+            self.assertEqual([self.app_id, domain], expected, msg)
 
             # Delete
             url = '/v2/apps/{app_id}/domains/{hostname}'.format(hostname=domain,
@@ -107,7 +107,11 @@ class DomainTest(TestCase):
                 content_type='application/json',
                 HTTP_AUTHORIZATION='token {}'.format(self.token)
             )
-            self.assertEqual(0, response.data['count'], msg)
+            self.assertEqual(1, response.data['count'], msg)
+
+            # verify only app domain is left
+            expected = [data['domain'] for data in response.data['results']]
+            self.assertEqual([self.app_id], expected, msg)
 
     def test_delete_domain_does_not_exist(self):
         """Remove a domain that does not exist"""
@@ -146,7 +150,7 @@ class DomainTest(TestCase):
     def test_delete_domain_does_not_remove_others(self):
         """https://github.com/deis/deis/issues/3475"""
         self.test_delete_domain_does_not_remove_latest()
-        self.assertEqual(Domain.objects.all().count(), 1)
+        self.assertEqual(Domain.objects.all().count(), 2)
 
     def test_manage_domain_invalid_app(self):
         # Create domain

--- a/rootfs/scheduler/abstract.py
+++ b/rootfs/scheduler/abstract.py
@@ -7,7 +7,7 @@ class AbstractSchedulerClient(object):
     def __init__(self, target):
         self.target = target
 
-    def create(self, name, image, command, **kwargs):
+    def create(self, name, **kwargs):
         """Create a new container."""
         raise NotImplementedError
 

--- a/rootfs/scheduler/chaos.py
+++ b/rootfs/scheduler/chaos.py
@@ -12,12 +12,12 @@ STOP_ERROR_RATE = 0
 
 class ChaosSchedulerClient(MockSchedulerClient):
 
-    def create(self, name, image, command, **kwargs):
+    def create(self, name, **kwargs):
         """Create a new container."""
         if random.random() < CREATE_ERROR_RATE:
             jobs.setdefault(name, {})['state'] = JobState.error
         else:
-            super(ChaosSchedulerClient, self).create(name, image, command, **kwargs)
+            super(ChaosSchedulerClient, self).create(name, **kwargs)
 
     def destroy(self, name):
         """Destroy a container."""

--- a/rootfs/scheduler/mock.py
+++ b/rootfs/scheduler/mock.py
@@ -5,6 +5,8 @@ import base64
 from .abstract import AbstractSchedulerClient
 from .states import JobState, TransitionError
 
+import logging
+logger = logging.getLogger(__name__)
 
 # HACK: MockSchedulerClient is not persistent across requests
 jobs = {}
@@ -12,8 +14,7 @@ secrets = {}
 
 
 class MockSchedulerClient(AbstractSchedulerClient):
-
-    def create(self, name, image, command, **kwargs):
+    def create(self, name, **kwargs):
         """Create a new container."""
         jobs.setdefault(name, {})['state'] = JobState.created
 


### PR DESCRIPTION
This modifies things so that k8s resources are created during app creation, allowing Domains and other resources to be added on at any point, even before a deploy.
Changes the world a little bit around if a scale vs deploy internally is called on first deploy (as it was before)

Technically this change brings in the ability to change the target port based on a deploy but that's just a by product

Fixes #420