### PR TITLE
fix(scheduler): handle pod log response as utf-8

### DIFF
--- a/rootfs/scheduler/__init__.py
+++ b/rootfs/scheduler/__init__.py
@@ -486,7 +486,9 @@ class KubeHTTPClient(AbstractSchedulerClient):
                 data = response.text
                 pod = response.json()
                 if pod['status']['phase'] == 'Succeeded':
-                    log = self._pod_log(appname, name).text
+                    response = self._pod_log(appname, name)
+                    response.encoding = 'utf-8'  # defaults to "ISO-8859-1" otherwise...
+                    log = response.text
                     self._delete_pod(appname, name)
                     return 0, log
                 if pod['status']['phase'] == 'Running':


### PR DESCRIPTION
The `requests` library was defaulting to ISO-8859-1 when decoding the k8s pod GET request, which could mangle the output from `deis run`. Explicitly [setting the encoding](http://docs.python-requests.org/en/master/user/quickstart/#response-content) fixes this.

It didn't appear to be worthwhile writing this behavior into the mock scheduler for a unit test (although please do talk me out of that rationalization), but this will be covered by [a spec in config_test.go](https://github.com/deis/workflow-e2e/blob/master/tests/config_test.go#L148) once that is enabled.

Closes #478.