### PR TITLE
fix(serializers): validate tags properly as k8s labels

### DIFF
--- a/rootfs/api/tests/test_config.py
+++ b/rootfs/api/tests/test_config.py
@@ -509,12 +509,33 @@ class ConfigTest(TransactionTestCase):
         tags4 = response.data
         self.assertNotEqual(tags3['uuid'], tags4['uuid'])
         self.assertNotIn('rack', json.dumps(response.data['tags']))
+        # set valid values
+        body = {'tags': json.dumps({'kubernetes.io/hostname': 'valid'})}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 201)
+        body = {'tags': json.dumps({'is.valid': 'is-also_valid'})}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 201)
+        body = {'tags': json.dumps({'host.the-name.com/is.valid': 'valid'})}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 201)
         # set invalid values
         body = {'tags': json.dumps({'valid': 'in\nvalid'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 400)
-        body = {'tags': json.dumps({'in.valid': 'valid'})}
+        body = {'tags': json.dumps({'host.name.com/notvalid-': 'valid'})}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 400)
+        body = {'tags': json.dumps({'valid': 'invalid.'})}
+        response = self.client.post(url, json.dumps(body), content_type='application/json',
+                                    HTTP_AUTHORIZATION='token {}'.format(self.token))
+        self.assertEqual(response.status_code, 400)
+        body = {'tags': json.dumps({'host.name.com/,not.valid': 'valid'})}
         response = self.client.post(url, json.dumps(body), content_type='application/json',
                                     HTTP_AUTHORIZATION='token {}'.format(self.token))
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/user-guide/labels.md#syntax-and-character-set for an explanation of what is legal in a k8s label key and value. Previously Deis was disallowing the slash `/` character which could denote a DNS-style prefix for a label key.

See also deis/workflow-e2e#67, which this unblocks.