### PR TITLE
fix(k8s): recreate basic k8s resource required for apps if they are missing

### DIFF
--- a/rootfs/api/views.py
+++ b/rootfs/api/views.py
@@ -220,9 +220,6 @@ class AppViewSet(BaseDeisViewSet):
 
         return Response(serializer.data)
 
-    def post_save(self, app):
-        app.create()
-
     def scale(self, request, **kwargs):
         new_structure = {}
         app = self.get_object()


### PR DESCRIPTION
gunicorn reload will fix things up, as will a deploy and scale operation.

Test steps:
* Start an app
* Delete the `minio-user secret`, `service` or `namespace*
* verify that the k8s resource is gone
* restart `deis-workflow` or trigger a deploy or run a scale operation
* verify that the k8s resource is back

Example of an app created, service is deleted, the workflow pod deleted (for cycling of gunicorn and such) and then verify that service is back

```
workflow  (fix_app_save>) $ deis create --no-remote
Creating Application... done, created dainty-headwind
remote available at ssh://git@deis.micro-kube.io:2222/dainty-headwind.git
workflow  (fix_app_save>) $ k get svc --namespace dainty-headwind
NAME              CLUSTER_IP   EXTERNAL_IP   PORT(S)   SELECTOR                                     AGE
dainty-headwind   10.3.0.30    <none>        80/TCP    app=dainty-headwind,heritage=deis,type=web   8s
workflow  (fix_app_save>) $ k delete svc dainty-headwind --namespace dainty-headwind
service "dainty-headwind" deleted
workflow  (fix_app_save>) $ k get svc --namespace dainty-headwind
NAME      CLUSTER_IP   EXTERNAL_IP   PORT(S)   SELECTOR   AGE
workflow  (fix_app_save>) $ k get po
NAME                  READY     STATUS    RESTARTS   AGE
deis-builder-98njw    1/1       Running   1          4m
deis-database-05qck   1/1       Running   1          4m
deis-minio-pm8o7      1/1       Running   0          4m
deis-registry-pydtx   1/1       Running   2          4m
deis-router-q72el     1/1       Running   1          4m
deis-workflow-o73qk   1/1       Running   1          2m
workflow  (fix_app_save>) $ k delete po deis-workflow-o73qk
pod "deis-workflow-o73qk" deleted
workflow  (fix_app_save>) $ k get svc --namespace dainty-headwind
NAME              CLUSTER_IP   EXTERNAL_IP   PORT(S)   SELECTOR                                     AGE
dainty-headwind   10.3.0.232   <none>        80/TCP    app=dainty-headwind,heritage=deis,type=web   1m
```

Using the same app and the same way to restart workflow, but this time delete the `namespace` of the application

```

workflow  (fix_app_save>) $ k delete ns dainty-headwind
namespace "dainty-headwind" deleted
workflow  (fix_app_save>) $ k get ns
NAME            LABELS          STATUS    AGE
default         <none>          Active    8d
deis            heritage=deis   Active    8m
kube-system     <none>          Active    8d
test-52125013   <none>          Active    4d
workflow  (fix_app_save>) $ k get ns
NAME              LABELS          STATUS    AGE
dainty-headwind   <none>          Active    3m
default           <none>          Active    8d
deis              heritage=deis   Active    11m
kube-system       <none>          Active    8d
test-52125013     <none>          Active    4d
workflow  (fix_app_save>) $ k get svc --namespace dainty-headwind
NAME              CLUSTER_IP   EXTERNAL_IP   PORT(S)   SELECTOR                                     AGE
dainty-headwind   10.3.0.110   <none>        80/TCP    app=dainty-headwind,heritage=deis,type=web   3m
```


Example of a new app that gets deploy, service gets deleted and then a deploy with a service checked after
```
rootfs  (fix_app_save>) $ deis create --no-remote
Creating Application... done, created klutzy-zeppelin
remote available at ssh://git@deis.micro-kube.io:2222/klutzy-zeppelin.git
rootfs  (fix_app_save>) $ deis pull deis/example-go -a klutzy-zeppelin
Creating build... done
rootfs  (fix_app_save>) $ k delete svc klutzy-zeppelin --namespace klutzy-zeppelin
service "klutzy-zeppelin" deleted
rootfs  (fix_app_save>) $ k get svc klutzy-zeppelin --namespace klutzy-zeppelin
Error from server: services "klutzy-zeppelin" not found
rootfs  (fix_app_save>) $ deis config:set foo=bar -a klutzy-zeppelin
Creating config... done

=== klutzy-zeppelin Config
foo      bar
rootfs  (fix_app_save>) $ k get svc klutzy-zeppelin --namespace klutzy-zeppelin
NAME              CLUSTER_IP   EXTERNAL_IP   PORT(S)   SELECTOR                                     AGE
klutzy-zeppelin   10.3.0.187   <none>        80/TCP    app=klutzy-zeppelin,heritage=deis,type=cmd   22s
```