### PR TITLE
chore(travis): move travis to Python only testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
-language: go
-go:
-  - 1.5.1
-env:
-  - GO15VENDOREXPERIMENT=1
+language: python
+python:
+  - 3.5
 branches:
   only:
     - master
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $HOME/venv
 services:
   - docker
   - postgresql
@@ -19,9 +13,6 @@ addons:
 before_install:
   - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb"
   - sudo dpkg -i shellcheck_0.3.7-5_amd64.deb
-  - sudo pip install virtualenv
-  - virtualenv -p python3.5 $HOME/venv
-  - source $HOME/venv/bin/activate
   - createdb -U postgres deis
 install:
   - pip install -r rootfs/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ include versioning.mk
 SHELL_SCRIPTS = $(wildcard rootfs/bin/*) $(shell find "rootfs" -name '*.sh') $(wildcard _scripts/*.sh)
 
 # Get the component informtation to a tmp location and get replica count
+KUBE := $(shell which kubectl)
+ifdef KUBE
 $(shell kubectl get rc deis-$(COMPONENT) --namespace deis -o yaml > /tmp/deis-$(COMPONENT))
 DESIRED_REPLICAS=$(shell kubectl get -o template rc/deis-$(COMPONENT) --template={{.status.replicas}} --namespace deis)
+endif
 
 check-docker:
 	@if [ -z $$(which docker) ]; then \


### PR DESCRIPTION
Many things are included by default when using python as the language (https://docs.travis-ci.com/user/languages/python)

Removing caching since we are in sudo mode so no caching is happning but also the pip directory is already cache if we are on the container based infrastructure (https://docs.travis-ci.com/user/caching/#pip-cache)