### PR TITLE
doc(managing): Remove managing disk usage page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,6 @@ pages:
   - Managing Workflow:
     - Configuring Load Balancers: managing-workflow/configuring-load-balancers.md
     - Configuring DNS: managing-workflow/configuring-dns.md
-    - Managing Disk Usage: managing-workflow/managing-disk-usage.md
     - Operational Tasks: managing-workflow/operational-tasks.md
     - Platform Logging: managing-workflow/platform-logging.md
     - Platform Monitoring: managing-workflow/platform-monitoring.md

--- a/src/managing-workflow/managing-disk-usage.md
+++ b/src/managing-workflow/managing-disk-usage.md
@@ -1,3 +1,0 @@
-# Managing Disk Usage
-
-TODO (bacongobbler): rewrite for v2


### PR DESCRIPTION
afaik (and someone correct me, _please_, if I have this wrong), the kubelet handles "garbage collection" for dead containers and stale/unused images.  In contrast to Deis v1.x, I don't think there's anything to really say on the topic of managing disk usage.