### PR TITLE
ref(themes/deis): remove IRC from social menu

### DIFF
--- a/themes/deis/base.html
+++ b/themes/deis/base.html
@@ -38,7 +38,6 @@
                     <footer>
                         <div class="social-menu">
                             <a href="https://twitter.com/opendeis" target="_blank"><span class="twitter"></span></a>
-                            <a href="https://botbot.me/freenode/deis/" target="_blank"><span class="irc"></span></a>
                             <a href="https://github.com/deis/workflow" target="_blank"><span class="github"></span></a>
                             <a href="http://stackoverflow.com/questions/tagged/deis?sort=active" target="_blank"><span class="stack"></span></a>
                         </div>


### PR DESCRIPTION
optimally we should replace this with a slack icon, but our social menu palette doesn't have a slack icon.

closes #121