### PR TITLE
ref(docs): remove "using a proxy server"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,6 @@ pages:
     - Security Considerations: managing-workflow/security-considerations.md
     - Platform SSL: managing-workflow/platform-ssl.md
     - Upgrading Workflow: managing-workflow/upgrading-workflow.md
-    - Using a Proxy Server: managing-workflow/using-a-proxy-server.md
   - Customizing Workflow:
     - CLI Plugins: customizing-workflow/cli-plugins.md
   - Troubleshooting:

--- a/src/managing-workflow/using-a-proxy-server.md
+++ b/src/managing-workflow/using-a-proxy-server.md
@@ -1,3 +1,0 @@
-# Using a Proxy Server
-
-TODO (bacongobbler): rewrite for v2


### PR DESCRIPTION
We have no documentation on this, nor does kubernetes. Removing for
the time being until we add this back.