### PR TITLE
fix(themes): fix up navigation on readthedocs

### DIFF
--- a/themes/deis/base.html
+++ b/themes/deis/base.html
@@ -63,28 +63,28 @@
                 <a class="fork" href="http://github.com/deis/workflow"><div class="forkImage"></div></a>
                 <div class="docs-border"></div>
                 <div class="navigation">
-                    {%- include "nav.html" %}
+                    <ul class="current">
+                        {%- include "nav.html" %}
+                        <li class="toctree-l1">
+                            {% if READTHEDOCS %}
+                                <a class="reference internal" href="../" state="open">Versions</a>
+                                <ul class="current">
+                                    {% for slug, url in versions %}
+                                        <li class="toctree-l2"><a href="{{ url }}{%- for word in pagename.split('/') -%}
+                                            {%- if word != 'index' -%}
+                                            {%- if word != '' -%}
+                                            {{ word }}/
+                                            {%- endif -%}
+                                            {%- endif -%}
+                                            {%- endfor -%}"
+                                            title="Switch to {{ slug }}">{{ slug }}</a></li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                        </li>
+                    </ul>
                     <div class="clearfix"></div>
                 </div>
-                <ul class="current">
-                    <li class="toctree-l1">
-                        {% if READTHEDOCS %}
-                            <a class="reference internal" href="../" state="open">Versions</a>
-                            <ul class="current">
-                                {% for slug, url in versions %}
-                                    <li class="toctree-l2"><a href="{{ url }}{%- for word in pagename.split('/') -%}
-                                        {%- if word != 'index' -%}
-                                        {%- if word != '' -%}
-                                        {{ word }}/
-                                        {%- endif -%}
-                                        {%- endif -%}
-                                        {%- endfor -%}"
-                                        title="Switch to {{ slug }}">{{ slug }}</a></li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
-                    </li>
-                </ul>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The version list is not being shown on readthedocs.org because it's
not in the navigation list.

addresses #1 but will keep open as I cannot verify until it's pushed and deployed to readthedocs. No breaking changes occurred locally, however.