### PR TITLE
fix(installing-workflow): bump requirement to kubernetes 1.2

### DIFF
--- a/src/installing-workflow/system-requirements.md
+++ b/src/installing-workflow/system-requirements.md
@@ -18,21 +18,7 @@ Running smaller machines will likely result in increased system load and has bee
 
 ## Versions
 
-Deis workflow has been tested with the Kubernetes v1.1 release line. While Kubernetes 1.2 may work we haven't fully tested that release.
-
-## Daemon Sets
-
-The logging components require Kubernetes Daemon Sets API. Daemon Sets are not enabled by default in the v1.1 release line. To enable these extensions, follow the instructions found [here](http://kubernetes.io/v1.1/docs/api.html#enabling-resources-in-the-extensions-group). If you are running Kubernetes v1.2, Daemon Sets are enabled by default.
-
-Specific steps to enable API extensions may vary based on your Kubernetes configuration. For example, to update a CoreOS Kubernetes cluster, edit the API server unit file and add the following line to the `ExecStart` stanza: `--runtime_config=extensions/v1beta1=true,extensions/v1beta1/daemonsets=true`.
-
-Restart your API server and check that the extensions API is enabled by running:
-
-```
-$ kubectl api-versions
-extensions/v1beta1
-v1
-```
+Deis workflow has been tested with the Kubernetes v1.2 release line. It is incompatible with Kubernetes v1.1 and lower.
 
 # Docker Requirements
 


### PR DESCRIPTION
workflow-beta2 and workflow-dev do not work on kubernetes 1.1 clusters.