### PR TITLE
docs(README.md): add slack signup & status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](https://deis.com/images/deis-logo.png)
 
+[![Slack Status](https://slack.deis.io/badge.svg)](https://slack.deis.io/)
+
 **Deis Workflow** is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes][k8s-home] cluster, making it easy to deploy and manage applications.
 
 Deis Workflow is the second major release (v2) of the Deis PaaS. If you are looking for the CoreOS-based PaaS visit [https://github.com/deis/deis](https://github.com/deis/deis).


### PR DESCRIPTION
[skip ci]

Adds a status badge that shows current participants in the https://slack.deis.io/ Slack channels and links to its signup page. Click on "View" here to see.

I'm not sure that's the best location for such a badge, but I thought this was nifty free functionality that could encourage community participation. Let me know if it should be relocated, and whether this is worthwhile.