### PR TITLE
ref(release-checklist): update "close github milestones"

### DIFF
--- a/src/roadmap/release-checklist.md
+++ b/src/roadmap/release-checklist.md
@@ -169,10 +169,10 @@ TAG=$DEIS_RELEASE TAG_MESSAGE="releasing workflow $DEIS_RELEASE" make git-tag gi
 
 # Step 8: Close GitHub milestones
 
-For each of the component projects listed at the top of this document, as well as for
-[workflow-cli](https://github.com/deis/workflow-cli), visit its GitHub repository and close
-the appropriate milestone. If there are still open issues attached to it, move them to
-the next upcoming milestone before closing.
+Close the github milestone by creating a new pull request at
+[seed-repo](https://github.com/deis/seed-repo). Any changes merged to master on that repository
+will be applied to all of the component projects. If there are open issues attached to the
+milestone, move them to the next upcoming milestone before merging the pull request.
 
 # Step 9: Let everyone know
 


### PR DESCRIPTION
This process is completely automated now, so there should be a reduced amount of human error when
closing milestones.