### PR TITLE
doc(release): add an extra step to point to versions.deis.com

### DIFF
--- a/src/roadmap/release-checklist.md
+++ b/src/roadmap/release-checklist.md
@@ -112,6 +112,8 @@ to reference the official images. To do so, simply modify all `dockerTag` entrie
 `generate_params.toml` files in the `workflow-$DEIS_RELEASE_SHORT` and
 `workflow-$DEIS_RELEASE_SHORT-e2e` to be `$DEIS_RELEASE` (instead of the ones based on git tags).
 
+Additionally, we want the official release chart to reference the production `versions.deis.com` API. Also in `generate_params.toml`, modify the `versionsApiURL` entry under `workflowManager` to have the value `https://versions.deis.com`.
+
 Also, ensure that the `README.md` and `Chart.yaml` files in the new helm classic chart have updated references to the chart. For example, references to `helmc install workflow-betaX` should become `helmc install workflow-$DEIS_RELEASE_SHORT`
 
 If you find any references that should be bumped, open a pull-request against the documentation.


### PR DESCRIPTION
CI-generated workflow charts for dev and testing currently instruct `workflow-manager` to source versions data from `https://versions-staging.deis.com`. This is a reminder to point to `https://versions.deis.com` as a part of the release process.