### PR TITLE
docs(index): move version header to index

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -8,6 +8,8 @@ configuration, creating and rolling back releases, managing domain names and SSL
 routing, aggregating logs, and sharing applications with teams. All of this is exposed through a simple REST API and
 command line interface.
 
+Please note that this documentation is for Deis Workflow (v2). For v1 documentation visit <http://docs.deis.io/en/latest/>.
+
 ## Getting Started
 
 To get started with Workflow, follow our [Quick Start][quickstart] guide.
@@ -18,6 +20,7 @@ sections.
 ## Service and Support
 
 If you are interested in commercial service and support for Deis Workflow, check out the various [services offerings on deis.com](https://deis.com/services).
+
 
 [arch]: understanding-workflow/architecture.md
 [concepts]: understanding-workflow/concepts.md

--- a/themes/deis/base.html
+++ b/themes/deis/base.html
@@ -29,11 +29,6 @@
         <div class="row">
             <div class="span9 column_calc contents">
                 <div class="doc-content">
-                    <div class="version-warning important">
-                        <p class="version-warning-title">Version 2</p>
-                        <p>This documentation is for Deis Workflow (v2). For v1 documentation visit <a href="http://docs.deis.io/en/latest/">http://docs.deis.io/en/latest/</a>.</p>
-                    </div>
-
                     {{ content }}
                 </div>
             </div>


### PR DESCRIPTION
We don't require the warning on every page, and it's not something that needs to stick out on the landing page.

closes #83