### PR TITLE
docs(managing-workflow): remove daemon set warning

### DIFF
--- a/src/managing-workflow/platform-logging.md
+++ b/src/managing-workflow/platform-logging.md
@@ -1,11 +1,8 @@
 # Platform Logging
 
-**You must have the Daemon Sets api enabled for the logging system to work. To learn more visit [here](https://github.com/kubernetes/kubernetes/blob/master/docs/api.md#enabling-resources-in-the-extensions-group).**
-
-## Description
 The logging platform is made up of 2 components - [Fluentd](https://github.com/deis/fluentd) and [Logger](https://github.com/deis/logger).
 
-[Fluentd](https://github.com/deis/fluentd) runs on every worker node of the cluster and is deployed as a [Daemons Set](http://kubernetes.io/v1.1/docs/admin/daemons.html). The Fluentd pods capture all of the stderr and stdout streams of every container running on the host (even those not hosted directly by kubernetes). It then sends this data via the Syslog UDP port (514) to the Logger component.
+[Fluentd](https://github.com/deis/fluentd) runs on every worker node of the cluster and is deployed as a [Daemon Set](http://kubernetes.io/v1.1/docs/admin/daemons.html). The Fluentd pods capture all of the stderr and stdout streams of every container running on the host (even those not hosted directly by kubernetes). It then sends this data via the Syslog UDP port (514) to the Logger component.
 
 Logger acts like a syslog server and receives all log messages that are occurring on the cluster. It then filters this data to only Deis deploy applications and stores those log messages in a ring buffer where they can be fetched via the Deis CLI.
 


### PR DESCRIPTION
Daemon sets are standard with kubernetes v1.2 and is pointed out in the system requirements.