### PR TITLE
docs(upgrading-workflow): copy DB creds into new chart

### DIFF
--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -4,11 +4,15 @@ To upgrade to a newer version of Workflow, run the following:
 
 ```
 $ helmc uninstall workflow-beta3 -n deis
-$ helmc update
 $ helmc fetch deis/workflow-beta4
 $ helmc generate -x manifests workflow-beta4
+$ cp `helmc home`/workspace/charts/workflow-beta3/manifests/deis-database-secret-creds.yaml \
+    `helmc home`/workspace/charts/workflow-beta4/manifests/
 $ helmc install workflow-beta4
 ```
+
+Make sure to copy the existing `deis-database-secret-creds.yaml` manifest into the new chart
+location *after* `helmc generate` to keep database credentials intact.
 
 ## Off-Cluster Storage Required
 


### PR DESCRIPTION
If this step is missed during upgrade, the controller and database won't be able to communicate.

I also removed the `helmc update` line since `helmc fetch` will do that for you if it doesn't find the chart referenced.