### PR TITLE
fix(reference-guide/controller-api): v1->v2

### DIFF
--- a/src/reference-guide/controller-api/v2.0.md
+++ b/src/reference-guide/controller-api/v2.0.md
@@ -13,7 +13,7 @@ This is the v2.0 REST API for the Controller.
 Example Request:
 
 ```
-POST /v1/auth/register/ HTTP/1.1
+POST /v2/auth/register/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 
@@ -62,7 +62,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/auth/login/ HTTP/1.1
+POST /v2/auth/login/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 
@@ -85,7 +85,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-DELETE /v1/auth/cancel/ HTTP/1.1
+DELETE /v2/auth/cancel/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -107,7 +107,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-POST /v1/auth/tokens/ HTTP/1.1
+POST /v2/auth/tokens/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -137,7 +137,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/auth/passwd/ HTTP/1.1
+POST /v2/auth/passwd/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 
@@ -172,7 +172,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/apps HTTP/1.1
+GET /v2/apps HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -208,7 +208,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/ HTTP/1.1
+POST /v2/apps/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -244,7 +244,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-DELETE /v1/apps/example-go/ HTTP/1.1
+DELETE /v2/apps/example-go/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -262,7 +262,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/apps/example-go/ HTTP/1.1
+GET /v2/apps/example-go/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -291,7 +291,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/ HTTP/1.1
+POST /v2/apps/example-go/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -318,7 +318,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-GET /v1/apps/example-go/logs/ HTTP/1.1
+GET /v2/apps/example-go/logs/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -343,7 +343,7 @@ Content-Type: text/plain
 ### Run one-off Commands
 
 ```
-POST /v1/apps/example-go/run/ HTTP/1.1
+POST /v2/apps/example-go/run/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -369,7 +369,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-GET /v1/certs HTTP/1.1
+GET /v2/certs HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -400,7 +400,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-GET /v1/certs/test.example.com HTTP/1.1
+GET /v2/certs/test.example.com HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -428,7 +428,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/certs/ HTTP/1.1
+POST /v2/certs/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -470,7 +470,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-DELETE /v1/certs/test.example.com HTTP/1.1
+DELETE /v2/certs/test.example.com HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -490,7 +490,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/apps/example-go/pods/ HTTP/1.1
+GET /v2/apps/example-go/pods/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -522,7 +522,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-GET /v1/apps/example-go/pods/web/ HTTP/1.1
+GET /v2/apps/example-go/pods/web/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -554,7 +554,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/pods/restart/ HTTP/1.1
+POST /v2/apps/example-go/pods/restart/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -583,7 +583,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/pods/web/restart/ HTTP/1.1
+POST /v2/apps/example-go/pods/web/restart/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -612,7 +612,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/pods/go-v2-web-atots/restart/ HTTP/1.1
+POST /v2/apps/example-go/pods/go-v2-web-atots/restart/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -641,7 +641,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/scale/ HTTP/1.1
+POST /v2/apps/example-go/scale/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -664,7 +664,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/apps/example-go/config/ HTTP/1.1
+GET /v2/apps/example-go/config/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -697,7 +697,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/config/ HTTP/1.1
+POST /v2/apps/example-go/config/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -738,7 +738,7 @@ X-Deis-Release: 3
 Example Request:
 
 ```
-POST /v1/apps/example-go/config/ HTTP/1.1
+POST /v2/apps/example-go/config/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -779,7 +779,7 @@ X-Deis-Release: 4
 Example Request:
 
 ```
-GET /v1/apps/example-go/domains/ HTTP/1.1
+GET /v2/apps/example-go/domains/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -813,7 +813,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/domains/ HTTP/1.1
+POST /v2/apps/example-go/domains/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 
@@ -842,7 +842,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-DELETE /v1/apps/example-go/domains/example.example.com HTTP/1.1
+DELETE /v2/apps/example-go/domains/example.example.com HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -862,7 +862,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/apps/example-go/builds/ HTTP/1.1
+GET /v2/apps/example-go/builds/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -902,7 +902,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/builds/ HTTP/1.1
+POST /v2/apps/example-go/builds/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -949,7 +949,7 @@ X-Deis-Release: 4
 Example Request:
 
 ```
-GET /v1/apps/example-go/releases/ HTTP/1.1
+GET /v2/apps/example-go/releases/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1009,7 +1009,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-GET /v1/apps/example-go/releases/v1/ HTTP/1.1
+GET /v2/apps/example-go/releases/v2/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1040,7 +1040,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/releases/rollback/ HTTP/1.1
+POST /v2/apps/example-go/releases/rollback/ HTTP/1.1
 Host: deis.example.com
 Content-Type: application/json
 Authorization: token abc123
@@ -1066,7 +1066,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-GET /v1/keys/ HTTP/1.1
+GET /v2/keys/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1101,7 +1101,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/keys/ HTTP/1.1
+POST /v2/keys/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 
@@ -1134,7 +1134,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-DELETE /v1/keys/example HTTP/1.1
+DELETE /v2/keys/example HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1158,7 +1158,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/apps/example-go/perms/ HTTP/1.1
+GET /v2/apps/example-go/perms/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1184,7 +1184,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/apps/example-go/perms/ HTTP/1.1
+POST /v2/apps/example-go/perms/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 
@@ -1204,7 +1204,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-DELETE /v1/apps/example-go/perms/example HTTP/1.1
+DELETE /v2/apps/example-go/perms/example HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1222,7 +1222,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/admin/perms/ HTTP/1.1
+GET /v2/admin/perms/ HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1261,7 +1261,7 @@ Content-Type: application/json
 Example Request:
 
 ```
-POST /v1/admin/perms HTTP/1.1
+POST /v2/admin/perms HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 
@@ -1285,7 +1285,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-DELETE /v1/admin/perms/example HTTP/1.1
+DELETE /v2/admin/perms/example HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```
@@ -1309,7 +1309,7 @@ DEIS_PLATFORM_VERSION: 2.0.0
 Example Request:
 
 ```
-GET /v1/users HTTP/1.1
+GET /v2/users HTTP/1.1
 Host: deis.example.com
 Authorization: token abc123
 ```


### PR DESCRIPTION
The API is now v2, but docs still reference v1.

example:

```
$ curl -H "Content-Type: application/json" -X POST \
  -d '{"username": "admin","password": "admin","email": "admin@example.com"}' http://deis.10.233.62.119.nip.io/v2/auth/register/
```