### PR TITLE
fix(upgrading-workflow): typo in database secret path

### DIFF
--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -77,7 +77,7 @@ $ helmc generate -x manifests workflow-rc2
 
 # copy your active database secrets into the helmc workspace
 $ cp ~/active-deis-database-secret-creds.yaml \
-	$(helmc home)/workspace/charts/workflow-rc2-manifests/deis-database-secret-creds.yaml
+	$(helmc home)/workspace/charts/workflow-rc2/manifests/deis-database-secret-creds.yaml
 
 # copy your active builder ssh keys into the helmc workspace
 $ cp ~/active-deis-builder-secret-ssh-private-keys.yaml \


### PR DESCRIPTION
found this typo while testing the in-place upgrade workflow for workflow-v2.0.0.