### PR TITLE
docs(roadmap): update release schedule terms for Workflow

### DIFF
--- a/src/roadmap/release-schedule.md
+++ b/src/roadmap/release-schedule.md
@@ -1,95 +1,82 @@
 # Release Schedule
 
-Some of the greatest assets of the Deis project are velocity and agility.
-Deis changed rapidly and with relative ease during initial development.
+Some of the greatest assets of the Deis team are velocity and agility. Workflow changed rapidly and
+with relative ease during initial development.
 
-Deis now harnesses those strengths into powering a regular, public release
-cadence. From v1.0.0 onward, the Deis project will release a minor version each
-month, with patch versions as needed. The project will use GitHub milestones to
-communicate the content and timing of major and minor releases.
+Deis now harnesses those strengths into powering a regular, public release cadence. From v2.0.0
+onward, the Deis team will release a minor version every 2 weeks, with patch versions as needed.
+The project will use GitHub milestones to communicate the content and timing of major and minor
+releases.
 
-Deis releases are not feature-based, in that dates are not linked to specific
-features. If a feature is merged before the release date, it is included in the
-next minor or major release.
+Deis releases are not feature-based, in that dates are not linked to specific features. If a
+feature is merged before the release date, it is included in the next minor or major release.
 
-The master `git` branch of Deis always works. Only changes considered ready to
-be released publicly are merged, and releases are made from master.
+The master `git` branch of Deis should always work. Only changes considered ready to be released
+publicly are merged, and non-patch releases are cut from master.
 
 ## Semantic Versioning
 
 Deis releases comply with [semantic versioning][], with the "public API" broadly
 defined as:
 
-- the REST API for *deis-controller*
-- etcd keys and values that are publicly documented
-- `deis` commands and options
-- essential `Makefile` targets
-- provider scripts under `contrib/`
+- the REST API for [the Controller][controller]
+- `deis` CLI commands and options
 
-Users of Deis can be confident that upgrading to a patch or to a minor release
-will not change the behavior of these items in a backward-incompatible way.
+Users of Workflow can be confident that upgrading to a patch or to a minor release will not change
+the behavior of these items in a backward-incompatible way.
 
 ## Release Criteria
 
-For any Deis release to be made publicly available, it must meet at least
-these criteria:
+For any Workflow release to be made publicly available, it must meet at least these criteria:
 
 - Passes all tests on the supported, load-balancing cloud providers
 - Has no new regressions in behavior that are not considered trivial
 
 ## Patch Releases
 
-A patch release of Deis includes backwards-compatible bug fixes. Upgrading to
-this version is safe and can be done in-place.
+A patch release of Workflow includes backwards-compatible bug fixes. Upgrading to this version is
+safe and can be done in-place.
 
-Backwards-compatible bug fixes to Deis are merged into the master branch at any
-time after they have [two approval comments][merge approval].
+Backwards-compatible bug fixes to Workflow are merged into the master branch at any time after they
+have [two approval comments][merge approval].
 
-Patch releases are created as often as needed, based on the priority of one or
-more bug fixes that have been merged. If time or severity is crucial, an
-individual maintainer can create a patch release without consensus from others.
-Patch releases are created from a previous release by cherry-picking specific
-bug fixes from the master branch, then applying and pushing the new release tag.
+Patch releases are created as often as needed, based on the priority of one or more bug fixes that
+have been merged. If time or severity is crucial, an individual maintainer can create a patch
+release without consensus from others. Patch releases are created from a previous release by
+cherry-picking specific bug fixes from the master branch to the release branch, then applying and
+pushing the new release tag.
 
 ## Minor Releases
 
-A minor release of Deis introduces functionality in a backward-compatible
-manner. Upgrading to this version is safe and can be done in-place.
+A minor release of Workflow introduces functionality in a backward-compatible manner. Upgrading to
+this version is safe and can be done in-place.
 
-Backwards-compatible functionality changes to Deis are merged into the master
-branch after they have [two approval comments][merge approval], and after
-the PR has been assigned to a milestone tracking the minor release.
+Backwards-compatible functionality changes to Workflow are merged into the master branch after they
+have [two approval comments][merge approval], and after the PR has been assigned to a milestone
+tracking the minor release.
 
-It is preferable to merge several backwards-compatible functionality changes for
-a single minor release.
+It is preferable to merge several backwards-compatible functionality changes for a single minor
+release.
 
-The Deis project will use GitHub milestones to communicate the content and
-timing of planned minor releases. Currently project maintainers meet each week
-on Thursday afternoon to assign pull requests to milestones.
-
-The Deis project will release a minor version of the platform on the first
-Tuesday of each month. The target day may be shifted to accomodate holidays or
-unusual circumstances. If project maintainers agree, an additional minor release
-may occur between planned releases. Code freeze and further acceptance
-tests begin on the Thursday before a targeted release.
+The Deis team will use GitHub milestones to communicate the content and timing of planned minor
+releases.
 
 A minor release may be superceded by a major release.
 
 ## Major Releases
 
-A major release of Deis introduces incompatible API changes. Upgrading to this
-version may involve a backup and restore process. Custom integrations with Deis
+A major release of Workflow introduces incompatible API changes. Custom integrations with Workflow
 may need to be updated.
 
-Incompatible changes to Deis are merged into the master branch deliberately, by
-agreement among maintainers. In addition to
-[two approval comments][merge approval], the pull request must be assigned
-to a planning milestone for that release, at which point it can be merged when
-release activities and testing begin.
+Incompatible changes to Workflow are merged into the master branch deliberately, by agreement among
+maintainers. In addition to [two approval comments][merge approval], the pull request must be
+assigned to a planning milestone for that release, at which point it can be merged when release
+activities and testing begin.
 
-The Deis project will use GitHub milestones to communicate the content and
-timing of planned major releases.
+The Deis team will use GitHub milestones to communicate the content and timing of planned major
+releases.
 
 
+[controller]: ../understanding-workflow/components.md#controller
 [merge approval]: ../contributing/submitting-a-pull-request.md#merge-approval
 [semantic versioning]: http://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
This document explained what in Deis v1 was considered a breaking change, what occurred during a release, what a patch/minor/major release entails, and our release cadence. This PR brings it up to date with what we now call "Workflow" with its new release cadence as well as what we consider to be breaking API changes.

This is by no means final, but this PR does reflect what we discussed earlier today in the release process meeting.