### PR TITLE
docs(platform-ssl.md): correct example manifest

### DIFF
--- a/src/managing-workflow/platform-ssl.md
+++ b/src/managing-workflow/platform-ssl.md
@@ -65,8 +65,8 @@ metadata:
   namespace: deis
 type: Opaque
 data:
-  cert: LS0...tCg==
-  key: LS0...LQo=
+  tls.crt: LS0...tCg==
+  tls.key: LS0...LQo=
 ```
 
 Once you've created the `deis-router-plaform-cert.yaml` file, you can install the manifest with `kubectl create -f


### PR DESCRIPTION
Hi, the example manifest in the docs regarding Platform SSL setup needs to be corrected. The relevant  keys to specify the certificate and the key are `tls.crt` and `tls.key` (instead of `cert` and `key`).

See:
https://github.com/deis/router/blob/eb6b05c55873805c87cf69297c8ae32bf3f532cd/README.md#platform-certificate-example