### PR TITLE
docs(install-workflow): note that k8s 1.2.x is required

### DIFF
--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -1,6 +1,6 @@
 # Installing Deis Workflow
 
-This document is aimed at those who have already provisioned a Kubernetes cluster and want to install Deis Workflow. If
+This document is aimed at those who have already provisioned a Kubernetes v1.2.x cluster and want to install Deis Workflow. If
 you are just getting started with Kubernetes and Deis Workflow, follow our [quickstart guide](../quickstart/index.md)
 with help booting Kubernetes and installing Workflow.
 

--- a/src/installing-workflow/system-requirements.md
+++ b/src/installing-workflow/system-requirements.md
@@ -4,7 +4,7 @@ To run Deis Workflow on a Kubernetes cluster, there are a few requirements to ke
 
 ## Kubernetes Versions
 
-Deis Workflow has been tested with the **Kubernetes v1.2** release line. It is incompatible with Kubernetes v1.1 and earlier.
+Deis Workflow has been tested with the **Kubernetes v1.2** release line. It is incompatible with Kubernetes v1.1 and earlier. Kubernetes v1.3.0 introduces [a bug when mounting secrets](https://github.com/deis/workflow/issues/372) which prevents Deis Workflow from starting; hopefully this will be fixed in future releases of Kubernetes.
 
 ## Resource Requirements
 
@@ -37,4 +37,4 @@ If you are using Docker with OverlayFS, you must disable SELinux by adding `--se
 `EXTRA_DOCKER_OPTS`. For more background information, see:
 
 * [https://github.com/docker/docker/issues/7952](https://github.com/docker/docker/issues/7952)
-* [https://github.com/deis/postgres/issues/63](https://github.com/deis/postgres/issues/63)
+* [https://github.com/deis/workflow/issues/63](https://github.com/deis/postgres/issues/63)


### PR DESCRIPTION
Until https://github.com/kubernetes/kubernetes/issues/28616 and https://github.com/kubernetes/kubernetes/issues/28750 are fixed, Deis Workflow cannot start successfully on Kubernetes 1.3.x.