### PR TITLE
docs(base.html): remove link to Deis 1.0 docs

### DIFF
--- a/themes/deis/base.html
+++ b/themes/deis/base.html
@@ -33,9 +33,8 @@
       {%- include "offcanvas.html" %}
 
       <!-- banner at the top of the page for temporary announcements-->
-      <div data-alert class="alert-box alert banner text-center hide-for-small">
-        You're viewing docs for the latest release of <strong>Deis Workflow</strong>. For docs <a href="http://docs.deis.io">relating to Deis 1.0 click here</a>.
-      </div>
+      <!-- <div data-alert class="alert-box alert banner text-center hide-for-small">
+      </div> -->
 
       <div class="content-wrap">
 


### PR DESCRIPTION
I think the distracting big red banner about "You're viewing the latest release...for 1.0 click here" can be scrapped now that 1.0 has been in maintenance mode for a while. But maybe I'm jumping the gun? ping @slack.