### PR TITLE
docs(upgrading-workflow): update chart versions

### DIFF
--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -18,7 +18,7 @@ See [Configuring Object Storage][] to learn how to store your Workflow data off-
 ## Keeping Essential Components
 
 !!! note
-    "Keeper" upgrade behavior requires Helm Classic 0.8.0 or newer and the workflow-rc1
+    "Keeper" upgrade behavior requires Helm Classic 0.8.0 or newer and the workflow-v2.0.0
     or newer chart.
 
 Helm Classic recognizes when a manifest inside a chart is marked as a "keeper"

--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -31,7 +31,7 @@ intact so routing and DNS are preserved while reinstalling Workflow.
 To remove Workflow completely from a Kubernetes cluster, run the following:
 
 ```
-$ helmc uninstall -n deis -y workflow-dev
+$ helmc uninstall -n deis -y workflow-v2.1.0  # or the installed Workflow version
 $ kubectl delete ns deis  # Be sure you want to delete the
                           # Namespace and all its contents!
 ```


### PR DESCRIPTION
This PR looks forward to the workflow-v2.2.0 release. I also updated a reference to the `workflow-rc1` chart because while it's technically correct, we don't want to encourage anyone to use the old release candidate builds.

Fixes #391.