### PR TITLE
fix(installing): Add configuring registry docs to doc tree

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ pages:
     - System Requirements: installing-workflow/system-requirements.md
     - Configuring Object Storage: installing-workflow/configuring-object-storage.md
     - Configuring Postgres: installing-workflow/configuring-postgres.md
+    - Configuring the Registry: installing-workflow/configuring-registry.md
   - Users:
     - Command Line Interface: users/cli.md
     - Users and Registration: users/registration.md


### PR DESCRIPTION
Although documentation was recently added that details how to configure Workflow to use an external registry, that documentation was never included in the doc tree. This PR corrects that.