### PR TITLE
docs(tuning): update storage default for logger

### DIFF
--- a/src/managing-workflow/tuning-component-settings.md
+++ b/src/managing-workflow/tuning-component-settings.md
@@ -92,7 +92,7 @@ The following environment variables are tunable for the [Logger][] component:
 
 Setting           | Description
 ----------------- | ---------------------------------
-STORAGE_ADAPTER   | How to store logs that are sent to the logger (default: "memory")
+STORAGE_ADAPTER   | How to store logs that are sent to the logger. Legal values are "file", "memory", and "redis". (default: "redis")
 NUMBER_OF_LINES   | How many lines to store in the ring buffer (default: 1000)
 
 ## Customizing the Monitor


### PR DESCRIPTION
"redis" is the default in current Workflow charts.