### PR TITLE
fix(gutenbuild): do not build any pre-release tags

### DIFF
--- a/_scripts/gutenbuild
+++ b/_scripts/gutenbuild
@@ -12,7 +12,8 @@ dev_build_dest=$1/en/dev
 PATH=$HOME/.local/bin:$PATH BUILDDIR=${build_dest} make deps build
 
 # also build each version of the docs out to /en/<tag>
-for tag in $(git tag); do
+# NOTE(bacongobbler): do not build any pre-release tags
+for tag in $(git tag | grep -v "-alpha\|-beta\|-rc"); do
   tag_build_dest="$build_dest/en/$tag"
   git checkout $tag
   PATH=$HOME/.local/bin:$PATH BUILDDIR=${tag_build_dest} make deps build

--- a/_scripts/gutenbuild
+++ b/_scripts/gutenbuild
@@ -5,6 +5,9 @@ set -x
 
 build_dest=$1
 
+# ensure we are on the master branch before building
+git checkout master
+
 PATH=$HOME/.local/bin:$PATH BUILDDIR=${build_dest} make deps build
 
 # build again, this time to /en/dev
@@ -18,6 +21,3 @@ for tag in $(git tag | grep -v "-alpha\|-beta\|-rc"); do
   git checkout $tag
   PATH=$HOME/.local/bin:$PATH BUILDDIR=${tag_build_dest} make deps build
 done
-
-# restore back to master
-git checkout master


### PR DESCRIPTION
The pre-release tags do not have the `make deps` or `make build` targets. This PR removes them from the build process.