### PR TITLE
docs(*): migrate from Helm Classic to Helm

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ pages:
     - Configuring Object Storage: installing-workflow/configuring-object-storage.md
     - Configuring Postgres: installing-workflow/configuring-postgres.md
     - Configuring the Registry: installing-workflow/configuring-registry.md
-    - Workflow Helm Charts: installing-workflow/workflow-helm-charts.md
+    - Chart Provenance: installing-workflow/chart-provenance.md
   - Users:
     - Command Line Interface: users/cli.md
     - Users and Registration: users/registration.md

--- a/src/contributing/overview.md
+++ b/src/contributing/overview.md
@@ -6,19 +6,7 @@ Interested in contributing to a Deis project?  There are lots of ways to help.
 
 Find a bug? Want to see a new feature? Have a request for the maintainers? Open a Github issue in the applicable repository and we’ll get the conversation started.
 
-Our official support channels are:
-
-- GitHub issue queues:
-    - [builder](https://github.com/deis/builder/issues)
-    - [chart](https://github.com/deis/charts/issues)
-    - [database](https://github.com/deis/postgres/issues)
-    - [helm classic](https://github.com/helm/helm-classic/issues)
-    - [monitor](https://github.com/deis/monitor/issues)
-    - [registry](https://github.com/deis/registry/issues)
-    - [router](https://github.com/deis/router/issues)
-    - [workflow](https://github.com/deis/workflow/issues)
-    - [workflow-cli](https://github.com/deis/workflow-cli/issues)
-- [Deis #community Slack channel][slack]
+Our official support channel is the [Deis #community Slack channel][slack].
 
 Don't know what the applicable repository for an issue is? Open up in issue in [workflow][] or chat with a maintainer in the [Deis #community Slack channel][slack] and we'll make sure it gets to the right place.
 

--- a/src/installing-workflow/chart-provenance.md
+++ b/src/installing-workflow/chart-provenance.md
@@ -1,24 +1,13 @@
-# Workflow Helm charts
+# Chart Provenance
 
 As of Workflow [v2.8.0](../changelogs/v2.8.0.md), Deis has released [Kubernetes Helm][helm] charts for Workflow
 and for each of its [components](../understanding-workflow/components.md).
-
-## Installation
-
-Once [Helm][helm] is installed and its server component is running on a Kubernetes cluster, one may install Workflow with the following steps:
-```
-$ helm repo add deis https://charts.deis.com/workflow  # add the workflow charts repo
-
-$ helm install deis/workflow --version=v2.8.0 --namespace=deis -f <optional values file>  # injects resources into your cluster
-```
-
-## Chart Provenance
 
 Helm provides tools for establishing and verifying chart integrity.  (For an overview, see the [Provenance](https://github.com/kubernetes/helm/blob/master/docs/provenance.md) doc.)  All release charts from the Deis Workflow team are now signed using this mechanism.  
 
 The full `Deis, Inc. (Helm chart signing key) <security@deis.com>` public key can be found [here](../security/1d6a97d0.txt), as well as the [pgp.mit.edu](http://pgp.mit.edu/pks/lookup?op=vindex&fingerprint=on&search=0x17E526B51D6A97D0) keyserver and the official Deis Keybase [account][deis-keybase].  The key's fingerprint can be cross-checked against all of these sources.
 
-### Verifying a signed chart
+## Verifying a signed chart
 
 The public key mentioned above must exist in a local keyring before a signed chart can be verified.
 

--- a/src/installing-workflow/configuring-object-storage.md
+++ b/src/installing-workflow/configuring-object-storage.md
@@ -11,7 +11,7 @@ Every component that relies on object storage uses two inputs for configuration:
 1. Component-specific environment variables (e.g. `BUILDER_STORAGE` and `REGISTRY_STORAGE`)
 2. Access credentials stored as a Kubernetes secret named `objectstorage-keyfile`
 
-The helm classic chart for Deis Workflow can be easily configured to connect Workflow components to off-cluster object storage. Deis Workflow currently supports Google Compute Storage, Amazon S3, Azure Blob Storage and OpenStack Swift Storage.
+The helm chart for Deis Workflow can be easily configured to connect Workflow components to off-cluster object storage. Deis Workflow currently supports Google Compute Storage, Amazon S3, Azure Blob Storage and OpenStack Swift Storage.
 
 ### Step 1: Create storage buckets
 
@@ -25,172 +25,26 @@ If you provide credentials with sufficient access to the underlying storage, Wor
 
 If applicable, generate credentials that have create and write access to the storage buckets created in Step 1.
 
-If you are using AWS S3 and your Kubernetes nodes are configured with appropriate IAM API keys via InstanceRoles, you do not need to create API credentials. Do, however, validate that the InstanceRole has appropriate permissions to the configured buckets!
+If you are using AWS S3 and your Kubernetes nodes are configured with appropriate [IAM][aws-iam] API keys via InstanceRoles, you do not need to create API credentials. Do, however, validate that the InstanceRole has appropriate permissions to the configured buckets!
 
-### Step 3: Fetch Workflow charts
+### Step 3: Add Deis Repo
 
-If you haven't already fetched the Helm Classic chart, do so with `helmc fetch deis/workflow-v2.8.0`
+If you haven't already added the Helm repo, do so with `helm repo add deis https://charts.deis.com/workflow`
 
-### Step 4: Configure Workflow charts
+### Step 4: Configure Workflow Chart
 
-Operators should configure object storage by either populating a set of environment variables or editing the the Helm Classic parameters file before running `helmc generate`. Both options are documented below:
+Operators should configure object storage by editing the Helm values file before running `helm install`. To do so:
 
-**Option 1:** Using environment variables
-
-After setting a `STORAGE_TYPE` environment variable to the desired object storage type ("s3", "gcs", "azure", or "swift"), set the additional variables as required by the selected object storage:
-
-| Storage Type | Required Variables                                                                                                                                          | Notes                                                                                               |
-| ---          | ---                                                                                                                                                         | ---                                                                                                 |
-| s3           | `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGISTRY_BUCKET`, `AWS_DATABASE_BUCKET`, `AWS_BUILDER_BUCKET`, `S3_REGION`                                         | To use [IAM credentials][aws-iam], it is not necessary to set `AWS_ACCESS_KEY` or `AWS_SECRET_KEY`. |
-| gcs          | `GCS_KEY_JSON`, `GCS_REGISTRY_BUCKET`, `GCS_DATABASE_BUCKET`, `GCS_BUILDER_BUCKET`                                                                          |                                                                                                     |
-| azure        | `AZURE_ACCOUNT_NAME`, `AZURE_ACCOUNT_KEY`, `AZURE_REGISTRY_CONTAINER`, `AZURE_DATABASE_CONTAINER`, `AZURE_BUILDER_CONTAINER`                                |                                                                                                     |
-| swift        | `SWIFT_USERNAME`, `SWIFT_PASSWORD`, `SWIFT_AUTHURL`, `SWIFT_AUTHVERSION`, `SWIFT_REGISTRY_CONTAINER`, `SWIFT_DATABASE_CONTAINER`, `SWIFT_BUILDER_CONTAINER` | To specify tenant set `SWIFT_TENANT` if the auth version is 2 or later.                             |
-
-!!! note
-	These environment variables should be set **before** running `helmc generate` in Step 5.
-
-**Option 2:** Using template file `tpl/generate_params.toml` available at `$(helmc home)/workspace/charts/workflow-v2.8.0`
-
-* Edit Helm Classic chart by running `helmc edit workflow-v2.8.0` and look for the template file `tpl/generate_params.toml` (make sure you have the `$EDITOR` environment variable set with your favorite text editor)
-* Update the `storage` parameter to reference the platform you are using, e.g. `s3`, `azure`, `gcs`, or `swift`
+* Fetch the Helm values by running `helm inspect values deis/workflow | sed -n '1!p' > values.yaml`
+* Update the `global/storage` parameter to reference the platform you are using, e.g. `s3`, `azure`, `gcs`, or `swift`
 * Find the corresponding section for your storage type and provide appropriate values including region, bucket names, and access credentials.
-* Save your changes to `tpl/generate_params.toml`.
+* Save your changes.
 
 !!! note
-	You do not need to base64 encode any of these values as Helm Classic will handle encoding automatically.
+	You do not need to base64 encode any of these values as Helm will handle encoding automatically.
 
-### Step 5: Generate manifests
+You are now ready to run `helm install deis/workflow --namespace deis -f values.yaml` using your desired object storage.
 
-Generate the Workflow chart by running `helmc generate -x manifests workflow-v2.8.0` (if you have previously run this step, make sure you add `-f` to force its regeneration).
-
-### Step 6: Verify credentials
-
-Helm Classic stores the object storage configuration as a Kubernetes secret.
-
-You may check the contents of the generated file named `deis-objectstorage-secret.yaml` in the `helmc` workspace directory:
-```
-$ cat $(helmc home)/workspace/charts/workflow-v2.8.0/manifests/deis-objectstorage-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: objectstorage-keyfile
-...
-data:
-  accesskey: bm9wZSBub3BlCg==
-  secretkey: c3VwZXIgbm9wZSBub3BlIG5vcGUgbm9wZSBub3BlCg==
-  region: ZWFyZgo=
-  registry-bucket: bXlmYW5jeS1yZWdpc3RyeS1idWNrZXQK
-  database-bucket: bXlmYW5jeS1kYXRhYmFzZS1idWNrZXQK
-  builder-bucket: bXlmYW5jeS1idWlsZGVyLWJ1c2tldAo=
-```
-
-You are now ready to `helmc install workflow-v2.8.0` using your desired object storage.
-
-## Object Storage Configuration and Credentials
-
-During the `helmc generate` step, Helm Classic creates a Kubernetes secret in the Deis namespace named `objectstorage-keyfile`. The exact structure of the file depends on storage backend specified in `tpl/generate_params.toml`.
-
-```
-# Set the storage backend
-#
-# Valid values are:
-# - s3: Store persistent data in AWS S3 (configure in S3 section)
-# - azure: Store persistent data in Azure's object storage
-# - gcs: Store persistent data in Google Cloud Storage
-# - minio: Store persistent data on in-cluster Minio server
-# - swift: Store persistent data in OpenStack Swift object storage cluster
-storage = "minio"
-```
-
-Individual components map the master credential secret to either secret-backed environment variables or volumes. See below for the component-by-component locations.
-
-## Component Details
-
-### [deis/builder](https://github.com/deis/builder)
-
-The builder looks for a `BUILDER_STORAGE` environment variable, which it then uses as a key to look up the object storage location and authentication information from the `objectstore-creds` volume.
-
-### [deis/slugbuilder](https://github.com/deis/slugbuilder)
-
-Slugbuilder is configured and launched by the builder component. Slugbuilder reads credential information from the standard `objectstorage-keyfile` secret.
-
-If you are using slugbuilder as a standalone component the following configuration is important:
-
-- `TAR_PATH` - The location of the application `.tar` archive, relative to the configured bucket for builder e.g. `home/burley-yeomanry:git-3865c987/tar`
-- `PUT_PATH` - The location to upload the finished slug, relative to the configured bucket of builder e.g. `home/burley-yeomanry:git-3865c987/push`
-- `CACHE_PATH` - The location to upload the cache, relative to the configured bucket of builder e.g. `home/burley-yeomanry/cache`
-
-!!! note
-	These environment variables are case-sensitive.
-
-### [deis/slugrunner](https://github.com/deis/slugrunner)
-
-Slugrunner is configured and launched by the controller inside a Workflow cluster. If you are using slugrunner as a standalone component the following configuration is important:
-
-- `SLUG_URL` - environment variable containing the path of the slug, relative to the builder storage location, e.g. `home/burley-yeomanry:git-3865c987/push/slug.tgz`
-
-Slugrunner reads credential information from a `objectstorage-keyfile` secret in the current Kubernetes namespace.
-
-### [deis/dockerbuilder](https://github.com/deis/dockerbuilder)
-
-Dockerbuilder is configured and launched by the builder component. Dockerbuilder reads credential information from the standard `objectstorage-keyfile` secret.
-
-If you are using dockerbuilder as a standalone component the following configuration is important:
-
-- `TAR_PATH` - The location of the application `.tar` archive, relative to the configured bucket for builder e.g. `home/burley-yeomanry:git-3865c987/tar`
-
-### [deis/controller](https://github.com/deis/controller)
-
-The controller is responsible for configuring the execution environment for buildpack-based applications. Controller copies `objectstorage-keyfile` into the application namespace so slugrunner can fetch the application slug.
-
-The controller interacts through Kubernetes APIs and does not use any environment variables for object storage configuration.
-
-### [deis/registry](https://github.com/deis/registry)
-
-The registry looks for a `REGISTRY_STORAGE` environment variable which it then uses as a key to look up the object storage location and authentication information.
-
-The registry reads credential information by reading `/var/run/secrets/deis/registry/creds/objectstorage-keyfile`.
-
-This is the file location for the `objectstorage-keyfile` secret on the Pod filesystem.
-
-### [deis/database](https://github.com/deis/postgres)
-
-The database looks for a `DATABASE_STORAGE` environment variable, which it then uses as a key to look up the object storage location and authentication information
-
-Minio (`DATABASE_STORAGE=minio`):
-
-* `AWS_ACCESS_KEY_ID` via /var/run/secrets/deis/objectstore/creds/accesskey
-* `AWS_SECRET_ACCESS_KEY` via /var/run/secrets/deis/objectstore/creds/secretkey
-* `AWS_DEFAULT_REGION` is the Minio default of "us-east-1"
-* `BUCKET_NAME` is the on-cluster default of "dbwal"
-
-AWS (`DATABASE_STORAGE=s3`):
-
-* `AWS_ACCESS_KEY_ID` via /var/run/secrets/deis/objectstore/creds/accesskey
-* `AWS_SECRET_ACCESS_KEY` via /var/run/secrets/deis/objectstore/creds/secretkey
-* `AWS_DEFAULT_REGION` via /var/run/secrets/deis/objectstore/creds/region
-* `BUCKET_NAME` via /var/run/secrets/deis/objectstore/creds/database-bucket
-
-GCS (`DATABASE_STORAGE=gcs`):
-
-* `GS_APPLICATION_CREDS` via /var/run/secrets/deis/objectstore/creds/key.json
-* `BUCKET_NAME` via /var/run/secrets/deis/objectstore/creds/database-bucket
-
-Azure (`DATABASE_STORAGE=azure`):
-
-* `WABS_ACCOUNT_NAME` via /var/run/secrets/deis/objectstore/creds/accountname
-* `WABS_ACCESS_KEY` via /var/run/secrets/deis/objectstore/creds/accountkey
-* `BUCKET_NAME` via /var/run/secrets/deis/objectstore/creds/database-container
-
-Swift (`DATABASE_STORAGE=swift`):
-
-* `SWIFT_USERNAME` via /var/run/secrets/deis/objectstore/creds/username
-* `SWIFT_PASSWORD` via /var/run/secrets/deis/objectstore/creds/password
-* `SWIFT_AUTHURL` via /var/run/secrets/deis/objectstore/creds/authurl
-* `SWIFT_AUTHVERSION` via /var/run/secrets/deis/objectstore/creds/authversion
-* `SWIFT_TENANT` via /var/run/secrets/deis/objectstore/creds/tenant
-* `BUCKET_NAME` via /var/run/secrets/deis/objectstore/creds/database-container
 
 [minio]: ../understanding-workflow/components.md#object-storage
-[generate-params-toml]: https://github.com/deis/charts/blob/master/workflow-dev/tpl/generate_params.toml
 [aws-iam]: http://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html

--- a/src/installing-workflow/configuring-postgres.md
+++ b/src/installing-workflow/configuring-postgres.md
@@ -29,30 +29,16 @@ $ psql -h <host> -p <port> -d postgres -U <"postgres" or your own username>
 
 ## Configuring Workflow
 
-The Helm Classic chart for Deis Workflow can be easily configured to connect the Workflow controller component to an off-cluster PostgreSQL database.
+The Helm chart for Deis Workflow can be easily configured to connect the Workflow controller component to an off-cluster PostgreSQL database.
 
-* **Step 1:** If you haven't already fetched the Helm Classic chart, do so with `helmc fetch deis/workflow-v2.8.0`
-* **Step 2:** Update database connection details either by setting the appropriate environment variables _or_ by modifying the template file `tpl/generate_params.toml`. Note that environment variables take precedence over settings in `tpl/generate_params.toml`.
-    * **1.** Using environment variables:
-        * Set `DATABASE_LOCATION` to `off-cluster`.
-        * Set `DATABASE_HOST` to the hostname or public IP of your off-cluster PostgreSQL RDBMS.
-        * Set `DATABASE_PORT` to the port listened to by your off-cluster PostgreSQL RDBMS-- typically `5432`.
-        * Set `DATABASE_NAME` to the name of the database provisioned for use by Workflow's controller component-- typically `deis`.
-        * Set `DATABASE_USERNAME` to the username of the database user that owns the database-- typically `deis`.
-        * Set `DATABASE_PASSWORD` to the password for the database user that owns the database.
-    * **2.** Using template file `tpl/generate_params.toml`:
-        * Open the Helm Classic chart with `helmc edit workflow-v2.8.0` and look for the template file `tpl/generate_params.toml`
-        * Update the `database_location` parameter to `off-cluster`.
-        * Update the values in the `[database]` configuration section to properly reflect all connection details.
-        * Save your changes.
-    * Note: Whether using environment variables or `tpl/generate_params.toml`, you do not need to (and must not) base64 encode any values, as the Helm Classic chart will automatically handle encoding as necessary.
-* **Step 3:** Re-generate the Helm Classic chart by running `helmc generate -x manifests workflow-v2.8.0`
-* **Step 4:** Check the generated files in your `manifests` directory. You should see:
-    * `deis-controller-deployment.yaml` contains relevant connection details.
-    * `deis-database-secret-creds.yaml` exists and contains base64 encoded database username and password.
-    * No other database-related Kubernetes resources are defined. i.e. none of `database-database-service-account.yaml`, `database-database-service.yaml`, or `database-database-deployment.yaml` exist.
+* **Step 1:** If you haven't already fetched the values, do so with `helm inspect values deis/workflow | sed -n '1!p' > values.yaml`
+* **Step 2:** Update database connection details by modifying `values.yaml`:
+    * Update the `database_location` parameter to `off-cluster`.
+    * Update the values in the `[database]` configuration section to properly reflect all connection details.
+    * Save your changes.
+    * Note: you do not need to (and must not) base64 encode any values, as the Helm chart will automatically handle encoding as necessary.
 
-You are now ready to `helmc install workflow-v2.8.0` [as usual][installing].
+You are now ready to `helm install deis/workflow --namespace deis -f values.yaml` [as usual][installing].
 
 [database]: ../understanding-workflow/components.md#database
 [object storage]: configuring-object-storage.md

--- a/src/installing-workflow/configuring-registry.md
+++ b/src/installing-workflow/configuring-registry.md
@@ -11,57 +11,21 @@ Every component that relies on registry uses two inputs for configuration:
 1. Registry Location environment variable named `DEIS_REGISTRY_LOCATION`
 2. Access credentials stored as a Kubernetes secret named `registry-secret`
 
-The helm classic chart for Deis Workflow can be easily configured to connect Workflow components to off-cluster registry. Deis Workflow supports external registries which provide either short lived tokens which are valid only for a specified amount of time or long lived tokens(basic username/password) which are valid forever for authenticating to them. For those registries which provide short lived tokens for authentication Deis Workflow will generate and refresh them such that the deployed apps will only have access to the short lived tokens and not to the actual credentials for the registries.
+The Helm chart for Deis Workflow can be easily configured to connect Workflow components to off-cluster registry. Deis Workflow supports external registries which provide either short-lived tokens which are valid only for a specified amount of time or long-lived tokens (basic username/password) which are valid forever for authenticating to them. For those registries which provide short lived tokens for authentication, Deis Workflow will generate and refresh them such that the deployed apps will only have access to the short-lived tokens and not to the actual credentials for the registries.
 
-When using a private registry the docker images are no longer pulled by Deis Workflow Controller but rather is managed by Kubernetes. This will increase security and overall speed, however the `port` information can no longer be discovered. Instead the `port` information can be set via `deis config:set PORT=<port>` prior to deploying the application.  
+When using a private registry the docker images are no longer pulled by Deis Workflow Controller but rather is managed by Kubernetes. This will increase security and overall speed, however the `port` information can no longer be discovered. Instead the `port` information can be set via `deis config:set PORT=<port>` prior to deploying the application.
 Deis Workflow currently supports
   1. Google Container Registry([gcr][gcr]).
   2. EC2 Container Registry([ecr][ecr]).
   3. off-cluster storage providers like dockerhub, quay.io, etc., or self hosted docker registry.
 
-* **Step 1:** If you haven't already fetched the Helm Classic chart, do so with `helmc fetch deis/workflow-v2.8.0`
-* **Step 2:** Update registry location details either by setting the appropriate environment variables _or_ by modifying the template file `tpl/generate_params.toml`. Note that environment variables take precedence over settings in `tpl/generate_params.toml`.
-    * **1.** Using environment variables: Set `REGISTRY_LOCATION` to `off-cluster`, `ecr` or `gcr`, then set the following environment variables accordingly.
-          * For `REGISTRY_LOCATION=gcr`:
+* **Step 1:** If you haven't already fetched the values file, do so with `helm inspect values deis/workflow | sed -n '1!p' > values.yaml`
+* **Step 2:** Update registry location details by modifying the values file.
+    * Update the `registry_location` parameter to reference the registry location you are using: `off-cluster`, `ecr`, `gcr`
+    * Update the values in the section which corresponds to your registry location type.
+    * Note: you do not need to base64 encode any of these values as Helm will handle encoding automatically
 
-            ```
-            export GCR_KEY_JSON, GCR_HOSTNAME
-            ```
-
-            `GCR_KEY_JSON`: The contents of the [service account][srvAccount] JSON key file.  
-            `GCR_HOSTNAME` can be empty and needs to be set if host name is different from "https://gcr.io".
-
-          * For `REGISTRY_LOCATION=ecr`:
-
-            ```
-            export ECR_ACCESS_KEY, ECR_SECRET_KEY, ECR_REGION, ECR_REGISTRY_ID, ECR_HOSTNAME
-            ```
-
-              `ECR_ACCESS_KEY` and `ECR_SECRET_KEY` are an AWS access key ID and secret access key with permission to use the container registry. To use [IAM credentials][aws-iam], it is not necessary to set either value, in which case the credentials used to provision the cluster will be used.
-
-              If `ECR_REGISTRY_ID` is empty, the default registry for the provisioning account will be used.
-
-              `ECR_HOSTNAME` only needs to be set if the default hostname is an alias (CNAME) or if the cluster is behind a proxy.
-
-
-          * For `REGISTRY_LOCATION=off-cluster`:
-
-            ```
-            export REGISTRY_USERNAME, REGISTRY_PASSWORD, REGISTRY_HOSTNAME, REGISTRY_ORGANIZATION
-            ```
-
-            If `REGISTRY_HOSTNAME` is not set then Workflow assumes it to be Dockerhub.  
-            `REGISTRY_ORGANIZATION` can be left empty if there is no namespacing in the registry. A [namespace][namespace] is a collection of repositories with a common name prefix.
-
-    * **2.** Using template file `tpl/generate_params.toml`:
-          * Open the helm classic chart with `helmc edit workflow-v2.8.0` and look for the template file `tpl/generate_params.toml`
-          * Update the `registry_location` parameter to reference the registry location you are using: `off-cluster`, `ecr`, `gcr`
-          * Update the values in the section which corresponds to your registry location type.
-      * Note: you do not need to base64 encode any of these values as Helm Classic will handle encoding automatically
-* **Step 3:** Save your changes and re-generate the helm classic chart by running `helmc generate -x manifests workflow-v2.8.0`
-* **Step 4:** Check the generated file in your manifests directory, you should see `deis-registry-secret.yaml`
-
-        You are now ready to `helmc install workflow-v2.8.0` using your desired registry.
+You are now ready to `helm install deis/workflow --namespace deis -f values.yaml` using your desired registry.
 
 [registry]: ../understanding-workflow/components.md#registry
 [storage]: configuring-object-storage

--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -7,36 +7,17 @@ Deis Workflow, follow the [quickstart guide](../quickstart/index.md) for assista
 ## Prerequisites
 
 1. Verify the [Kubernetes system requirements](system-requirements.md)
-1. Install [Helm Classic and Deis Workflow CLI](../quickstart/install-cli-tools.md) tools
+1. Install [Helm and Deis Workflow CLI](../quickstart/install-cli-tools.md) tools
 
 ## Check Your Setup
 
-Check that the `helmc` command is available and the version is 0.8 or newer.
+Check that the `helm` command is available and the version is 2.0.0 or newer.
 
 ```
-$ helmc --version
-helmc version 0.8.1+a9c55cf
+$ helm version
+Client: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
 ```
-
-Ensure the `kubectl` client is installed and can connect to the Kubernetes cluster. `helmc` uses `kubectl` to interact
-with the Kubernetes cluster.
-
-`helmc` can be verified it is working properly by running:
-
-```
-$ helmc target
-Kubernetes master is running at https://52.9.206.49
-Elasticsearch is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/elasticsearch-logging
-Heapster is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/heapster
-Kibana is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/kibana-logging
-KubeDNS is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/kube-dns
-kubernetes-dashboard is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard
-Grafana is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana
-InfluxDB is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/monitoring-influxdb
-```
-
-If `helmc target` shows a list of targets like the one above, `helmc` can communicate with the Kubernetes master. Double check that
-the master returned by `helmc target` matches the expected cluster.
 
 ## Choose Your Deployment Strategy
 
@@ -54,39 +35,24 @@ More rigorous installations would benefit from using outside sources for the fol
 
 ## Add the Deis Chart Repository
 
-The [Deis Chart Repository](https://github.com/deis/charts) contains everything needed to install Deis Workflow onto
-a Kubernetes cluster, with a single `helmc install` command.
+The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
 
-Add this repository to Helm Classic:
+Add this repository to Helm:
 
 ```
-$ helmc repo add deis https://github.com/deis/charts
+$ helm repo add deis https://charts.deis.com/workflow
 ```
 
 ## Install Deis Workflow
 
-Now that Helm Classic is installed and the Deis Chart Repository has been added, install Workflow by running:
+Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helmc fetch deis/workflow-v2.8.0            # fetches the chart into a
-                                              # local workspace
-$ helmc generate -x manifests workflow-v2.8.0 # generates various secrets
-$ helmc install workflow-v2.8.0               # injects resources into
-                                              # your cluster
+$ helm install deis/workflow --namespace deis
 ```
 
-!!! Experimental
-	Workflow can also be installed now using the [Kubernetes Helm][helm]. All the details that are needed for a production deployments like off-cluster storage, external registry etc., can be configured by passing an optional [values file][valuesfile] which overrides default values.
-
-
-    	$ helm repo add deis https://charts.deis.com/workflow  # add the workflow charts repo
-
-    	$ helm install deis/workflow --version=v2.8.0 --namespace=deis -f <optional values file>  # injects resources into your cluster
-
-  See also our section on [Workflow chart provenance](workflow-helm-charts.md#chart-provenance)
-
-Helm Classic will install a variety of Kubernetes resources in the `deis` namespace.
-Wait for the pods that Helm Classic launched to be ready. Monitor their status by running:
+Helm will install a variety of Kubernetes resources in the `deis` namespace.
+Wait for the pods that Helm launched to be ready. Monitor their status by running:
 
 ```
 $ kubectl --namespace=deis get pods

--- a/src/managing-workflow/tuning-component-settings.md
+++ b/src/managing-workflow/tuning-component-settings.md
@@ -1,31 +1,22 @@
 # Tuning Component Settings
 
 Helm Charts are a set of Kubernetes manifests that reflect best practices for deploying an
-application or service. Helm is heavily influenced by [Homebrew](http://brew.sh/), including the
-[formula model](https://github.com/Homebrew/homebrew-core). A Helm Chart is to Helm as a Formula
-is to Homebrew.
+application or service on Kubernetes.
 
-After you fetch the Workflow chart, you can customize the chart using `helmc edit` before using
-`helmc generate` and `helmc install` to complete the installation. To customize the respective
-component, edit `tpl/deis-<component>-deployment.yaml` and modify the `env` section of the component to
-tune these settings.
-
-For example, to allow only administrators to register new accounts in the controller,
-edit `tpl/deis-controller-deployment.yaml` and add the following under the `env` section:
-
-```
-env:
-  - name: REGISTRATION_MODE
-    value: "admin_only"
-```
+After you add the Deis Chart Repository, you can customize the chart using
+`helm inspect values deis/workflow | sed -n '1!p' > values.yaml` before using `helm install` to complete the
+installation. To customize the respective component, edit `values.yaml` and modify the section of
+the component to tune these settings.
 
 ## Setting Resource limits
 
-You can set resource limits to Workflow components by modifying the template file `tpl/generate_params.toml`.
-This file has a section for each Workflow component. To set a limit to any Workflow component just add `limits_cpu`, `limits_memory`
-in the section and set them to the appropriate values.
+You can set resource limits to Workflow components by modifying the values.yaml file fetched
+earlier. This file has a section for each Workflow component. To set a limit to any Workflow
+component just add `limits_cpu`, `limits_memory` in the section and set them to the appropriate
+values.
 
-Below is an example of how the builder section of `tpl/generate_params.toml` might look with CPU and memory limits set:
+Below is an example of how the builder section of `values.yaml` might look with CPU and memory
+limits set:
 
 ```
 [builder]

--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -2,10 +2,8 @@
 
 Deis Workflow releases may be upgraded in-place with minimal downtime. This upgrade process requires:
 
-* Helm Classic, version [0.8.0 or newer](https://github.com/helm/helm-classic/releases/tag/0.8.0)
+* Helm version [2.0.0 or newer](https://github.com/kubernetes/helm/releases/tag/v2.0.0)
 * Configured Off-Cluster Storage
-* A copy of the database and builder secrets from your running cluster
-* Workflow manifests annotated with `helm-keep: true` (rc1 or later)
 * A Kubernetes cluster with more than one node is required for the rolling upgrade of the deis-router (as it is a rolling upgrade with host ports)
 
 ## Off-Cluster Storage Required
@@ -16,145 +14,21 @@ of [Minio][] will result in data loss.**
 
 See [Configuring Object Storage][] to learn how to store your Workflow data off-cluster.
 
-## Keeping Essential Components
-
-!!! note
-    "Keeper" upgrade behavior requires Helm Classic 0.8.0 or newer and the workflow-v2.0.0
-    or newer chart.
-
-Helm Classic recognizes when a manifest inside a chart is marked as a "keeper"
-and will not uninstall the annotated resource during `helmc uninstall`.
-
-The Workflow Chart marks the "deis" Kubernetes `Namespace` and the `Service`
-for the registry and router as keepers. This leaves the external `LoadBalancer`
-intact so routing and DNS are preserved while reinstalling Workflow.
-
-See the Helm Classic documentation for more detail about [keeper manifests].
-
 ## Upgrade Process
 
-### Step 1: Verify component annotations and prepare upgrade
+### Step 1: Apply the Workflow upgrade
 
-To verify that the deis namespace and all the deis-* services are marked as "keepers," run a
-command like this one for each component:
+Helm will remove all components from the previous release. Traffic to applications deployed through
+Workflow will continue to flow during the upgrade. No service interruptions should occur.
 
-```
-$ kubectl --namespace=deis get service deis-router \
-	--output=go-template='{{ index .metadata.annotations "helm-keep" | println }}'
-true
-```
-
-Manifests that are annotated correctly should return the value "true". To add a missing annotation, use `kubectl annotate`:
+If Workflow is not configured to use off-cluster Postgres, the Workflow API will experience a brief
+period of downtime while the database recovers from backup.
 
 ```
-$ kubectl --namespace=deis annotate namespace deis helm-keep=true
-namespace "deis" annotated
+$ helm upgrade deis/workflow
 ```
 
-Exporting environment variables for the previous and latest versions will help reduce confusion later on:
-
-```
-$ export PREVIOUS_WORKFLOW_RELEASE=v2.7.0
-$ export DESIRED_WORKFLOW_RELEASE=v2.8.0
-```
-
-### Step 2: Fetch new charts
-
-Workflow charts are always published with a version number intact. The command `helmc update` updates the local chart
-repository to the latest set of releases.
-
-```
-# update the charts repo
-$ helmc update
-```
-
-Fetching the new chart copies the chart from the chart cache into the helmc workspace for customization.
-
-```
-# fetch new chart
-$ helmc fetch deis/workflow-${DESIRED_WORKFLOW_RELEASE}
-```
-
-### Step 3: Fetch builder, database, and platform SSL credentials
-
-The first time Workflow is installed, Helm automatically generates secrets for the builder and database components.
-When upgrading, take care to use credentials from the running Workflow installation. The following commands export the
-secrets to the local workstation. They will be copied into place in a later step.
-
-```
-# fetch the current database credentials to the local workstation
-$ kubectl --namespace=deis get secret database-creds -o yaml > ~/active-deis-database-secret-creds.yaml
-
-# fetch the builder component ssh keys to the local workstation
-$ kubectl --namespace=deis get secret builder-ssh-private-keys -o yaml > ~/active-deis-builder-secret-ssh-private-keys.yaml
-```
-
-#### Optional: Fetch platform SSL credentials
-Installations that have installed a [platform SSL](https://deis.com/docs/workflow/managing-workflow/platform-ssl/) certificate and private key on the router will need to save those secrets locally as well. They will be installed at a later step with the other credentials saved to the local workstation.
-
-```
-# fetch the platform SSL certificate and private key and store on the local workstation
-$ kubectl --namespace=deis get secret deis-router-platform-cert -o yaml > ~/active-deis-router-platform-cert.yaml
-```
-
-### Step 4: Modify and update configuration
-
-Before generating the manifests for the newest release, operators should update the new `generate_params.toml` to match
-configuration from the **previous release**.
-
-```
-# update your off-cluster storage configuration
-$ $EDITOR $(helmc home)/workspace/charts/workflow-${DESIRED_WORKFLOW_RELEASE}/tpl/generate_params.toml
-```
-
-```
-# generate templates for the new release
-$ helmc generate -x manifests workflow-${DESIRED_WORKFLOW_RELEASE}
-```
-
-### Step 5: Apply secrets
-
-After generating new manifests in the previous step, copy the current secrets into place:
-
-```
-# copy your active database secrets into the helmc workspace for the desired version
-$ cp ~/active-deis-database-secret-creds.yaml \
-	$(helmc home)/workspace/charts/workflow-${DESIRED_WORKFLOW_RELEASE}/manifests/deis-database-secret-creds.yaml
-
-# copy your active builder ssh keys into the helmc workspace for the desired version
-$ cp ~/active-deis-builder-secret-ssh-private-keys.yaml \
-	$(helmc home)/workspace/charts/workflow-${DESIRED_WORKFLOW_RELEASE}/manifests/deis-builder-secret-ssh-private-keys.yaml
-```
-
-If platform SSL credentials were saved in the Step 3, copy those secrets in place as well:
-```
-# copy your active platform SSL certificate and key into the helmc workspace for the desired version
-$ cp ~/active-deis-router-platform-cert.yaml \
-	$(helmc home)/workspace/charts/workflow-${DESIRED_WORKFLOW_RELEASE}/manifests/deis-router-platform-cert.yaml
-```
-
-!!! note
-    Make sure to copy the existing credentials manifests into the new chart
-    location *after* `helmc generate` to preserve credentials from the running system.
-
-### Step 6: Apply the Workflow upgrade
-
-Helm Classic will remove all components from the previous release that are **not** marked as keepers. As of Workflow
-2.3 and later, the controller, registry and router will be left in-service. Traffic to applications deployed through
-Worfklow will continue to flow between the `uninstall` and `install` commands.
-
-If Workflow is not configured to use off-cluster Postgres the Workflow API will experience a brief period of downtime
-while the database component recovers from backup.
-
-```
-# uninstall workflow
-$ helmc uninstall workflow-${PREVIOUS_WORKFLOW_RELEASE} -n deis
-
-# install latest workflow release
-$ helmc install workflow-${DESIRED_WORKFLOW_RELEASE}
-```
-
-### Step 7: Verify upgrade
+### Step 2: Verify Upgrade
 
 Verify that all components have started and passed their readiness checks:
 
@@ -186,14 +60,13 @@ deis-router-1357759721-a3ard             1/1       Running   0          5m
 deis-workflow-manager-2654760652-kitf9   1/1       Running   0          5m
 ```
 
-[configuring object storage]: ../installing-workflow/configuring-object-storage.md
-[keeper manifests]: http://helm-classic.readthedocs.io/en/latest/awesome/#keeper-manifests
-[minio]: https://github.com/deis/minio
+### Step 3: Upgrade the Deis Client
 
-### Step 7: Upgrade the deis client
-
-Your deis platform users should now upgrade their deis client to avoid getting `WARNING: Client and server API versions do not match. Please consider upgrading.` warnings.
+Users of Deis Workflow should now upgrade their deis client to avoid getting `WARNING: Client and server API versions do not match. Please consider upgrading.` warnings.
 
 ```
 curl -sSL http://deis.io/deis-cli/install-v2.sh | bash && sudo mv deis $(which deis)
 ```
+
+
+[minio]: https://github.com/deis/minio

--- a/src/quickstart/index.md
+++ b/src/quickstart/index.md
@@ -2,7 +2,7 @@
 
 Get started with Deis Workflow in three easy steps.
 
-1. Install CLI tools for Helm Classic and Deis Workflow
+1. Install CLI tools for Helm and Deis Workflow
 2. Boot a Kubernetes and install Deis Workflow
 3. Deploy your first application
 
@@ -10,7 +10,7 @@ This guide will help you set up a cluster suitable for evaluation, development a
 
 ## Step 1: Install CLI tools
 
-For the quickstart we will [install both Helm Classic and Deis Workflow CLI](install-cli-tools.md).
+For the quickstart we will [install both Helm and Deis Workflow CLI](install-cli-tools.md).
 
 ## Step 2: Boot Kubernetes and Install Deis Workflow
 

--- a/src/quickstart/install-cli-tools.md
+++ b/src/quickstart/install-cli-tools.md
@@ -19,37 +19,18 @@ should move it somewhere in your $PATH:
 Check your work by running `deis version`:
 
     $ deis version
-    2.7.0
+    2.8.0
 
 !!! note
     Note that version numbers may vary as new releases become available
 
-## Helm Classic Installation
+## Helm Installation
 
-We will install Deis Workflow using Helm Classic which is a tool for installing and managing software in a Kubernetes cluster.
+We will install Deis Workflow using Helm which is a tool for installing and managing software in a
+Kubernetes cluster.
 
-Install the latest `helmc` cli for Linux or Mac OS X with:
-
-    $ curl -sSL https://get.helm.sh | bash
-
-!!! note
-    Note that the `unzip` package is a requirement for this command
-
-The installer places the `helmc` binary in your current directory, but you
-should move it somewhere in your $PATH:
-
-    $ sudo ln -fs $PWD/helmc /usr/local/bin/helmc
-
-*or*:
-
-    $ sudo mv $PWD/helmc /usr/local/bin/helmc
-
-Check your work by running `helmc --version`:
-
-    $ helmc --version
-    helmc version 0.8.1+a9c55cf
-
-Make sure you are running at least version 0.8.1 or newer.
+Install the latest `helm` cli for Linux or Mac OS X by following the
+[installation instructions][helm-install].
 
 ## Step 2: Boot a Kubernetes Cluster and Install Deis Workflow
 
@@ -62,3 +43,6 @@ Cloud-based options:
 * [Amazon Web Services](provider/aws/boot.md): uses Kubernetes upstream `kube-up.sh` to boot a cluster on AWS EC2.
 
 If you would like to test on your local machine follow our guide for [Vagrant](provider/vagrant/boot.md).
+
+
+[helm-install]: https://github.com/kubernetes/helm#install

--- a/src/quickstart/provider/aws/install-aws.md
+++ b/src/quickstart/provider/aws/install-aws.md
@@ -1,76 +1,45 @@
-# Installing Deis Workflow
+# Installing Deis Workflow on Amazon Web Services
 
 ## Check Your Setup
 
-First check that the `helmc` command is available and the version is 0.8 or newer.
+First check that the `helm` command is available and the version is v2.0.0 or newer.
 
 ```
-$ helmc --version
-helmc version 0.8.1+a9c55cf
+$ helm version
+Client: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
 ```
 
-Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster. `helmc` will
-use it to communicate. You can test that it is working properly by running:
-
-```
-$ helmc target
-Kubernetes master is running at https://52.9.206.49
-Elasticsearch is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/elasticsearch-logging
-Heapster is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/heapster
-Kibana is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/kibana-logging
-KubeDNS is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/kube-dns
-kubernetes-dashboard is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard
-Grafana is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana
-InfluxDB is running at https://52.9.206.49/api/v1/proxy/namespaces/kube-system/services/monitoring-influxdb
-```
-
-If you see a list of targets like the one above, `helmc` can communicate with the Kubernetes master.
+Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.
 
 ## Add the Deis Chart Repository
 
-The [Deis Chart Repository](https://github.com/deis/charts) contains everything you
-need to install Deis onto your Kubernetes cluster, with a single `helmc install` command.
+The Deis Chart Repository contains everything you need to install Workflow onto your Kubernetes
+cluster, with a single `helm install deis/workflow --namespace deis` command.
 
-Run the following command to add this repository to Helm Classic:
+Run the following command to add this repository to Helm:
 
 ```
-$ helmc repo add deis https://github.com/deis/charts
+$ helm repo add deis https://charts.deis.com/workflow
 ```
-
-!!! note
-   You need [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed in order to run the command above
 
 ## Install Deis Workflow
 
-Now that you have Helm Classic installed and have added the Deis Chart Repository, install Workflow by running:
+Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helmc fetch deis/workflow-v2.8.0            # fetches the chart into a
-                                              # local workspace
-$ helmc generate -x manifests workflow-v2.8.0 # generates various secrets
-$ helmc install workflow-v2.8.0               # injects resources into
-                                              # your cluster
+$ helm install deis/workflow --namespace deis
 ```
 
-!!! Experimental
-	Workflow can also be installed now using the [Kubernetes Helm][helm]. All the details that are needed for a production deployments like off-cluster storage, external registry etc., can be configured by passing an optional [values file][valuesfile] which overrides default values.
-
-
-    	$ helm repo add deis https://charts.deis.com/workflow  # add the workflow charts repo
-
-    	$ helm install deis/workflow --version=v2.8.0 --namespace=deis -f <optional values file>  # injects resources into your cluster
-
-  See also our section on [Workflow chart provenance](../../../installing-workflow/workflow-helm-charts.md#chart-provenance)
-
-Helm Classic will install a variety of Kubernetes resources in the `deis` namespace.
-You'll need to wait for the pods that it launched to be ready. Monitor their status
-by running:
+Helm will install a variety of Kubernetes resources in the `deis` namespace.
+Wait for the pods that Helm launched to be ready. Monitor their status by running:
 
 ```
 $ kubectl --namespace=deis get pods
 ```
 
-If you would like `kubectl` to automatically update as the pod states change, run (type Ctrl-C to stop the watch):
+If it's preferred to have `kubectl` automatically update as the pod states change, run (type Ctrl-C to stop the watch):
+
 ```
 $ kubectl --namespace=deis get pods -w
 ```
@@ -79,7 +48,8 @@ Depending on the order in which the Workflow components initialize, some pods ma
 installation: if a component's dependencies are not yet available, that component will exit and Kubernetes will
 automatically restart it.
 
-Here, you can see that controller, builder and registry all took a few loops before there were able to start:
+Here, it can be seen that the controller, builder and registry all took a few loops before they were able to start:
+
 ```
 $ kubectl --namespace=deis get pods
 NAME                          READY     STATUS    RESTARTS   AGE
@@ -95,20 +65,21 @@ deis-router-k1ond             1/1       Running   0          5m
 deis-workflow-manager-68nu6   1/1       Running   0          5m
 ```
 
-Once you see all of the pods in the `READY` state, Deis Workflow is up and running!
+Once all of the pods are in the `READY` state, Deis Workflow is up and running!
 
 ## Configure your AWS Load Balancer
 
-After installing Workflow on your cluster, you will need to adjust your load balancer configuration.
-By default, the connection timeout for Elastic Load Blancers is 60 seconds. Unfortunately, this timeout is too short for
-long running connections when using `git push` functionality of Deis Workflow.
+After installing Workflow on your cluster, you will need to adjust your load balancer
+configuration. By default, the connection timeout for Elastic Load Blancers is 60 seconds.
+Unfortunately, this timeout is too short for long running connections when using `git push`
+functionality of Deis Workflow.
 
-Deis Workflow will automatically provision and attach a Elastic Loadbalancer to the router component. This
-component is responsible for routing HTTP and HTTPS requests from the public internet to applications that are deployed
-and managed by Deis Workflow.
+Deis Workflow will automatically provision and attach a Elastic Loadbalancer to the router
+component. This component is responsible for routing HTTP and HTTPS requests from the public
+internet to applications that are deployed and managed by Deis Workflow.
 
-By describing the `deis-router` service, you can see what IP hostname has been allocated by AWS for your Deis Workflow
-cluster:
+By describing the `deis-router` service, you can see what IP hostname has been allocated by AWS for
+your Deis Workflow cluster:
 
 ```
 $ kubectl --namespace=deis describe svc deis-router | egrep LoadBalancer
@@ -116,13 +87,16 @@ Type:                   LoadBalancer
 LoadBalancer Ingress:   abce0d48217d311e69a470643b4d9062-2074277678.us-west-1.elb.amazonaws.com
 ```
 
-The AWS name for the ELB is the first part of hostname, before the `-`. List all of your ELBs by name to confirm:
+The AWS name for the ELB is the first part of hostname, before the `-`. List all of your ELBs by
+name to confirm:
+
 ```
 $ aws elb describe-load-balancers --query 'LoadBalancerDescriptions[*].LoadBalancerName'
 abce0d48217d311e69a470643b4d9062
 ```
 
 Set the connection timeout to 1200 seconds, make sure you use your load balancer name:
+
 ```
 $ aws elb modify-load-balancer-attributes \
         --load-balancer-name abce0d48217d311e69a470643b4d9062 \
@@ -132,7 +106,3 @@ CONNECTIONSETTINGS	1200
 ```
 
 Next, [configure dns](dns.md) so you can register your first user and deploy an application.
-
-
-[helm]: https://github.com/kubernetes/helm/blob/master/docs/install.md
-[valuesfile]: https://charts.deis.com/workflow/values-v2.8.0.yaml

--- a/src/quickstart/provider/gke/install-gke.md
+++ b/src/quickstart/provider/gke/install-gke.md
@@ -2,70 +2,43 @@
 
 ## Check Your Setup
 
-First check that the `helm` command is available and the version is 0.8 or newer.
+First check that the `helm` command is available and the version is v2.0.0 or newer.
 
 ```
-$ helmc --version
-helmc version 0.8.1+a9c55cf
+$ helm version
+Client: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
 ```
 
-Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster. `helm` will
-use it to communicate. You can test that it is working properly by running:
-
-```
-$ helmc target
-Kubernetes master is running at https://104.154.234.246
-GLBCDefaultBackend is running at https://104.154.234.246/api/v1/proxy/namespaces/kube-system/services/default-http-backend
-Heapster is running at https://104.154.234.246/api/v1/proxy/namespaces/kube-system/services/heapster
-KubeDNS is running at https://104.154.234.246/api/v1/proxy/namespaces/kube-system/services/kube-dns
-kubernetes-dashboard is running at https://104.154.234.246/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard
-```
-
-If you see a list of targets like the one above, `helm` can communicate with the Kubernetes master.
-
+Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.
 
 ## Add the Deis Chart Repository
 
-The [Deis Chart Repository](https://github.com/deis/charts) contains everything you
-need to install Deis onto your Kubernetes cluster, with a single `helmc install` command.
+The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
 
-Run the following command to add this repository to Helm:
+Add this repository to Helm:
 
 ```
-$ helmc repo add deis https://github.com/deis/charts
+$ helm repo add deis https://charts.deis.com/workflow
 ```
 
 ## Install Deis Workflow
 
-Now that you have Helm installed and have added the Deis Chart Repository, install Workflow by running:
+Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helmc fetch deis/workflow-v2.8.0            # fetches the chart into a
-                                              # local workspace
-$ helmc generate -x manifests workflow-v2.8.0 # generates various secrets
-$ helmc install workflow-v2.8.0               # injects resources into
-                                              # your cluster
+$ helm install deis/workflow --namespace deis
 ```
 
-!!! Experimental
-	Workflow can also be installed now using the [Kubernetes Helm][helm]. All the details that are needed for a production deployments like off-cluster storage, external registry etc., can be configured by passing an optional [values file][valuesfile] which overrides default values.
-
-
-    	$ helm repo add deis https://charts.deis.com/workflow  # add the workflow charts repo
-
-    	$ helm install deis/workflow --version=v2.8.0 --namespace=deis -f <optional values file>  # injects resources into your cluster
-
-  See also our section on [Workflow chart provenance](../../../installing-workflow/workflow-helm-charts.md#chart-provenance)
-
-Helm Classic will install a variety of Kubernetes resources in the `deis` namespace.
-You'll need to wait for the pods that it launched to be ready. Monitor their status
-by running:
+Helm will install a variety of Kubernetes resources in the `deis` namespace.
+Wait for the pods that Helm launched to be ready. Monitor their status by running:
 
 ```
 $ kubectl --namespace=deis get pods
 ```
 
-If you would like `kubectl` to automatically update as the pod states change, run (type Ctrl-C to stop the watch):
+If it's preferred to have `kubectl` automatically update as the pod states change, run (type Ctrl-C to stop the watch):
+
 ```
 $ kubectl --namespace=deis get pods -w
 ```
@@ -74,26 +47,23 @@ Depending on the order in which the Workflow components initialize, some pods ma
 installation: if a component's dependencies are not yet available, that component will exit and Kubernetes will
 automatically restart it.
 
-Here, you can see that controller, builder and registry all took a few loops before there were able to start:
+Here, it can be seen that the controller, builder and registry all took a few loops before they were able to start:
+
 ```
 $ kubectl --namespace=deis get pods
 NAME                          READY     STATUS    RESTARTS   AGE
-deis-builder-miekp            1/1       Running   1          2m
-deis-controller-egu7x         1/1       Running   3          2m
-deis-database-ok3ev           1/1       Running   0          2m
-deis-logger-fluentd-d5cb9     1/1       Running   0          2m
-deis-logger-fluentd-u6azj     1/1       Running   0          2m
-deis-logger-rf3z9             1/1       Running   0          2m
-deis-minio-sdfyz              1/1       Running   0          2m
-deis-registry-f534k           1/1       Running   4          2m
-deis-router-t3qb2             1/1       Running   0          2m
-deis-workflow-manager-kbpw3   1/1       Running   0          2m
+deis-builder-hy3xv            1/1       Running   5          5m
+deis-controller-g3cu8         1/1       Running   5          5m
+deis-database-rad1o           1/1       Running   0          5m
+deis-logger-fluentd-1v8uk     1/1       Running   0          5m
+deis-logger-fluentd-esm60     1/1       Running   0          5m
+deis-logger-sm8b3             1/1       Running   0          5m
+deis-minio-4ww3t              1/1       Running   0          5m
+deis-registry-asozo           1/1       Running   1          5m
+deis-router-k1ond             1/1       Running   0          5m
+deis-workflow-manager-68nu6   1/1       Running   0          5m
 ```
 
-Once you see all of the pods in the `READY` state, Deis Workflow is up and running!
+Once all of the pods are in the `READY` state, Deis Workflow is up and running!
 
 Next, [configure dns](dns.md) so you can register your first user and deploy an application.
-
-
-[helm]: https://github.com/kubernetes/helm/blob/master/docs/install.md
-[valuesfile]: https://charts.deis.com/workflow/values-v2.8.0.yaml

--- a/src/quickstart/provider/vagrant/install-vagrant.md
+++ b/src/quickstart/provider/vagrant/install-vagrant.md
@@ -1,71 +1,44 @@
-# Installing Deis Workflow on Vagrant
+# Install Deis Workflow on Vagrant
 
 ## Check Your Setup
 
-First check that the `helm` command is available and the version is 0.8 or newer.
+First check that the `helm` command is available and the version is v2.0.0 or newer.
 
 ```
-$ helmc --version
-helmc version 0.8.1+a9c55cf
+$ helm version
+Client: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
 ```
 
-Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster. `helm` will
-use it to communicate. You can test that it is working properly by running:
-
-```
-$ helmc target
-Kubernetes master is running at https://10.245.1.2
-Heapster is running at https://10.245.1.2/api/v1/proxy/namespaces/kube-system/services/heapster
-KubeDNS is running at https://10.245.1.2/api/v1/proxy/namespaces/kube-system/services/kube-dns
-kubernetes-dashboard is running at https://10.245.1.2/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard
-Grafana is running at https://10.245.1.2/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana
-InfluxDB is running at https://10.245.1.2/api/v1/proxy/namespaces/kube-system/services/monitoring-influxdb
-```
-
-If you see a list of targets like the one above, `helm` can communicate with the Kubernetes master.
+Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.
 
 ## Add the Deis Chart Repository
 
-The [Deis Chart Repository](https://github.com/deis/charts) contains everything you
-need to install Deis onto your Kubernetes cluster, with a single `helmc install` command.
+The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
 
-Run the following command to add this repository to Helm:
+Add this repository to Helm:
 
 ```
-$ helmc repo add deis https://github.com/deis/charts
+$ helm repo add deis https://charts.deis.com/workflow
 ```
 
 ## Install Deis Workflow
 
-Now that you have Helm installed and have added the Deis Chart Repository, install Workflow by running:
+Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helmc fetch deis/workflow-v2.8.0            # fetches the chart into a
-                                              # local workspace
-$ helmc generate -x manifests workflow-v2.8.0 # generates various secrets
-$ helmc install workflow-v2.8.0               # injects resources into
-                                              # your cluster
+$ helm install deis/workflow --namespace deis
 ```
-
-!!! Experimental
-	Workflow can also be installed now using the [Kubernetes Helm][helm]. All the details that are needed for a production deployments like off-cluster storage, external registry etc., can be configured by passing an optional [values file][valuesfile] which overrides default values.
-
-
-    	$ helm repo add deis https://charts.deis.com/workflow   # add the workflow charts repo
-
-    	$ helm install deis/workflow --version=v2.8.0 --namespace=deis -f <optional values file>  # injects resources into your cluster
-
-  See also our section on [Workflow chart provenance](../../../installing-workflow/workflow-helm-charts.md#chart-provenance)
 
 Helm will install a variety of Kubernetes resources in the `deis` namespace.
-You'll need to wait for the pods that it launched to be ready. Monitor their status
-by running:
+Wait for the pods that Helm launched to be ready. Monitor their status by running:
 
 ```
 $ kubectl --namespace=deis get pods
 ```
 
-If you would like `kubectl` to automatically update as the pod states change, run (type Ctrl-C to stop the watch):
+If it's preferred to have `kubectl` automatically update as the pod states change, run (type Ctrl-C to stop the watch):
+
 ```
 $ kubectl --namespace=deis get pods -w
 ```
@@ -74,24 +47,23 @@ Depending on the order in which the Workflow components initialize, some pods ma
 installation: if a component's dependencies are not yet available, that component will exit and Kubernetes will
 automatically restart it.
 
+Here, it can be seen that the controller, builder and registry all took a few loops before they were able to start:
+
 ```
 $ kubectl --namespace=deis get pods
 NAME                          READY     STATUS    RESTARTS   AGE
-deis-builder-lrb54            1/1       Running   1          2m
-deis-controller-lto6v         1/1       Running   1          2m
-deis-database-2jh3w           1/1       Running   0          2m
-deis-logger-fluentd-9hm06     1/1       Running   0          2m
-deis-logger-yxhwk             1/1       Running   0          2m
-deis-minio-p384q              1/1       Running   0          2m
-deis-registry-l9l6g           1/1       Running   2          2m
-deis-router-yc3rb             1/1       Running   0          2m
-deis-workflow-manager-fw5vq   1/1       Running   0          2m
+deis-builder-hy3xv            1/1       Running   5          5m
+deis-controller-g3cu8         1/1       Running   5          5m
+deis-database-rad1o           1/1       Running   0          5m
+deis-logger-fluentd-1v8uk     1/1       Running   0          5m
+deis-logger-fluentd-esm60     1/1       Running   0          5m
+deis-logger-sm8b3             1/1       Running   0          5m
+deis-minio-4ww3t              1/1       Running   0          5m
+deis-registry-asozo           1/1       Running   1          5m
+deis-router-k1ond             1/1       Running   0          5m
+deis-workflow-manager-68nu6   1/1       Running   0          5m
 ```
 
-Once you see all of the pods in the `READY` state, Deis Workflow is up and running!
+Once all of the pods are in the `READY` state, Deis Workflow is up and running!
 
 Next, [configure dns](dns.md) so you can register your first user and deploy an application.
-
-
-[helm]: https://github.com/kubernetes/helm/blob/master/docs/install.md
-[valuesfile]: https://charts.deis.com/workflow/values-v2.8.0.yaml

--- a/src/reference-guide/migration.md
+++ b/src/reference-guide/migration.md
@@ -1,8 +1,8 @@
 # Migrating from Deis v1
 
-Workflow uses [`kubectl`][kubectl] and [`helmc`][helmc] to manage the cluster. These tools
-are equivalent to Deis v1's [`fleetctl`][fleetctl] and [`deisctl`][deisctl]. These two tools are
-used for managing the cluster's state, installing the platform and inspecting its state.
+Workflow uses [`kubectl`][kubectl] and [`helm`][helm] to manage the cluster. These tools are
+equivalent to Deis v1's [`fleetctl`][fleetctl] and [`deisctl`][deisctl]. These two tools are used
+for managing the cluster's state, installing the platform and inspecting its state.
 
 This document is a "cheat sheet" for users migrating from Deis v1 to Workflow (v2). It lists most of
 the known commands administrators would use with `deisctl` and translates their usage in Workflow.
@@ -75,4 +75,4 @@ $ kubectl --namespace=deis logs -f deis-builder-1851090495-5n0sn
 [deisctl]: http://docs.deis.io/en/latest/installing_deis/install-deisctl/
 [fleetctl]: https://github.com/coreos/fleet/blob/master/Documentation/using-the-client.md
 [kubectl]: http://kubernetes.io/docs/user-guide/kubectl-overview/
-[helmc]: https://github.com/helm/helm-classic
+[helm]: https://github.com/kubernetes/helm

--- a/src/troubleshooting/kubectl.md
+++ b/src/troubleshooting/kubectl.md
@@ -5,7 +5,7 @@ This document describes how one can use `kubectl` to debug any issues with the c
 ## Diving into the Components
 
 Using `kubectl`, one can inspect the cluster's current state. When Workflow is installed
-with `helmc`, Workflow is installed into the `deis` namespace. To inspect if Workflow is
+with `helm`, Workflow is installed into the `deis` namespace. To inspect if Workflow is
 running, run:
 
 	$ kubectl --namespace=deis get pods

--- a/src/understanding-workflow/architecture.md
+++ b/src/understanding-workflow/architecture.md
@@ -8,7 +8,7 @@ compliant Kubernetes cluster.
 
 ![System Overview](../diagrams/Ecosystem_Basic.png)
 
-Operators use [Helm Classic][helm] to configure and install the Workflow components which
+Operators use [Helm][] to configure and install the Workflow components which
 interface directly with the underlying Kubernetes cluster. Service discovery,
 container availability and networking are all delegated to Kubernetes, while
 Workflow provides a clean and simple developer experience.
@@ -64,6 +64,6 @@ configurations as well as multi-server production clusters.
 [builder]: components.md#builder
 [components]: components.md
 [controller]: components.md#controller
-[helm]: http://helm.sh
+[helm]: https://github.com/kubernetes/helm
 [logger]: components.md#logger
 [router]: components.md#router

--- a/src/understanding-workflow/concepts.md
+++ b/src/understanding-workflow/concepts.md
@@ -29,7 +29,7 @@ and managing deployment configurations and app releases are just some of the
 features Workflow adds.
 
 Deis Workflow is a set of Kubernetes-native components, installable via
-[Helm Classic][helm]. Systems engineers who are familiar with Kubernetes will feel right
+[Helm][]. Systems engineers who are familiar with Kubernetes will feel right
 at home running Workflow.
 
 See the [components][components] overview for more detail.
@@ -138,6 +138,6 @@ to external or third-party vendor services.
 [dockerfile]: ../applications/using-dockerfiles.md
 [dockerimage]: ../applications/using-docker-images.md
 [environment variables]: http://12factor.net/config
-[helm]: https://helm.sh
+[helm]: https://github.com/kubernetes/helm
 [release]: ../reference-guide/terms.md#release
 [slugrunner]: concepts.md#slugrunner


### PR DESCRIPTION
This changes all documentation to use Helm as the default tool for installing Deis
Workflow. Users of Helm Classic are urged to use https://github.com/deis/workflow-migration
to migrate from Helm Classic to Helm.

Note that I kept roadmap/releases.md intentionally left unchanged for now as we are still pumping out Helm Classic charts for v2.9.0 as far as I'm aware.