### PR TITLE
fix(managing-workflow): fix link to nsq.io

### DIFF
--- a/src/managing-workflow/platform-logging.md
+++ b/src/managing-workflow/platform-logging.md
@@ -4,7 +4,7 @@ The logging platform is made up of 2 components - [Fluentd](https://github.com/d
 
 [Fluentd](https://github.com/deis/fluentd) runs on every worker node of the cluster and is deployed as a [Daemon Set](http://kubernetes.io/v1.1/docs/admin/daemons.html). The Fluentd pods capture all of the stderr and stdout streams of every container running on the host (even those not hosted directly by kubernetes). Once the log message arrives in our [custom fluentd plugin](https://github.com/deis/fluentd/tree/master/rootfs/opt/fluentd/deis-output) we determine where the message originated.
 
-If the message was from the [Workflow Controller](https://github.com/deis/controller) or from an application deployed via workflow we send it to the logs topic on the local [NSQD](nsq.io) instance.
+If the message was from the [Workflow Controller](https://github.com/deis/controller) or from an application deployed via workflow we send it to the logs topic on the local [NSQD](http://nsq.io) instance.
 
 If the message is from the [Workflow Router](https://github.com/deis/router) we build an Influxdb compatible message and send it to the same NSQD instance but instead place the message on the metrics topic.
 


### PR DESCRIPTION
When the link does not provide a scheme, mkdocs considers it a local
link as opposed to an external link.

closes #614