### PR TITLE
docs(installing-workflow): deprecate support for v1.2 clusters

### DIFF
--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -1,6 +1,6 @@
 # Installing Deis Workflow
 
-This document is aimed at those who have already provisioned a [Kubernetes v1.2 or v1.3.4+][] cluster
+This document is aimed at those who have already provisioned a [Kubernetes v1.3.4+][] cluster
 and want to install Deis Workflow. If help is required getting started with Kubernetes and
 Deis Workflow, follow the [quickstart guide](../quickstart/index.md) for assistance.
 
@@ -89,6 +89,6 @@ Once all of the pods are in the `READY` state, Deis Workflow is up and running!
 
 After installing Workflow, [register a user and deploy an application](../quickstart/deploy-an-app.md).
 
-[Kubernetes v1.2 or v1.3.4+]: system-requirements.md#kubernetes-versions
+[Kubernetes v1.3.4+]: system-requirements.md#kubernetes-versions
 [helm]: https://github.com/kubernetes/helm/blob/master/docs/install.md
 [valuesfile]: https://charts.deis.com/workflow/values-v2.9.0.yaml

--- a/src/installing-workflow/system-requirements.md
+++ b/src/installing-workflow/system-requirements.md
@@ -4,12 +4,13 @@ To run Deis Workflow on a Kubernetes cluster, there are a few requirements to ke
 
 ## Kubernetes Versions
 
-Deis Workflow requires Kubernetes v1.2, or v1.3.4+ or v1.4.0+. Workflow is not compatible with
-Kubernetes v1.1, and Kubernetes v1.3.0 through v1.3.3 have
-[a bug when mounting secrets](https://github.com/deis/workflow/issues/372) which prevents Deis
-Workflow from starting.
 
-At this time Kubernetes 1.5 is not compatible with both Helm and Workflow.
+Deis Workflow requires the latest patch release of Kubernetes v1.3 or v1.4. Workflow is not
+compatible with Kubernetes v1.2, and Kubernetes v1.3.0 through v1.3.3 have
+[a bug when mounting secrets](https://github.com/deis/workflow/issues/372) which prevents Deis
+Workflow from starting. Kubernetes v1.4 is highly recommended but is not required.
+
+At this time, Kubernetes v1.5 is not compatible with Workflow v2.9.0.
 
 ## Storage Requirements
 

--- a/src/quickstart/provider/aws/boot.md
+++ b/src/quickstart/provider/aws/boot.md
@@ -251,16 +251,16 @@ need to access the Kubernetes master the default username is `admin` and the ssh
 ```
 $ ssh -i ~/.ssh/kube_aws_rsa admin@52.9.206.49
 
-Welcome to Kubernetes v1.2.4!
+Welcome to Kubernetes v1.3.6!
 
 You can find documentation for Kubernetes at:
   http://docs.kubernetes.io/
 
 You can download the build image for this release at:
-  https://storage.googleapis.com/kubernetes-release/release/v1.2.4/kubernetes-src.tar.gz
+  https://storage.googleapis.com/kubernetes-release/release/v1.3.6/kubernetes-src.tar.gz
 
 It is based on the Kubernetes source at:
-  https://github.com/kubernetes/kubernetes/tree/v1.2.4
+  https://github.com/kubernetes/kubernetes/tree/v1.3.6
 
 For Kubernetes copyright and licensing information, see:
   /usr/local/share/doc/kubernetes/LICENSES


### PR DESCRIPTION
We have not tested nor seen anyone use k8s v1.2 so I think it's fair to start dropping "official"
support for that minor release and just test against v1.3.4+ clusters.