### PR TITLE
Update command used to auth to kubernetes host

### DIFF
--- a/src/quickstart/provider/gke/boot.md
+++ b/src/quickstart/provider/gke/boot.md
@@ -72,11 +72,16 @@ If you haven't configured your default zone, make sure it matches the ZONE for y
 $ gcloud config set compute/zone us-central1-b
 ```
 
-Now you may fetch Kubernetes credentials:
+Now you may fetch credentials to connect to Kubernetes:
 ```
-$ gcloud container clusters get-credentials cluster-1
-Fetching cluster endpoint and auth data.
-kubeconfig entry generated for cluster-1.
+$ gcloud auth application-default login
+Your browser has been opened to visit:
+https://accounts.google.com/o/oauth2/auth?redirect_uri=....
+
+Credentials saved to file: [~/.config/gcloud/application_default_credentials.json]
+
+These credentials will be used by any library that requests
+Application Default Credentials.
 ```
 
 If you don't have `kubectl` CLI setup just yet, run this to get it available


### PR DESCRIPTION
Note that I'm a total newcomer to Deis. I also haven't verified this problem/fix from a technical point of view. It's worth sharing the fix here, though, in case it **is** verified and we want to fix it.

When I ran `$ kubectl cluster-info`, I got this error:
`error: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.`

Looks like the auth mechanism was updated a few months ago: https://github.com/kubernetes/kubernetes/issues/30617

> Previously, gcloud would have configured kubectl to use the cluster's static client certificate to authenticate. Now, gcloud is configuring kubectl to use the service account's credentials.
> 
> Kubectl is just using the Application Default Credentials library, and it looks like this is part of the ADC flow for using a JSON-key service account.

At the bottom of that thread, this command was suggested, which worked for me:
`$ gcloud auth application-default login`.