### PR TITLE
ref(*): require key_json chart value to be base64-encoded

### DIFF
--- a/charts/workflow/templates/objectstorage-secret.yaml
+++ b/charts/workflow/templates/objectstorage-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     deis.io/objectstorage: "{{ .Values.global.storage }}"
 type: Opaque
 data: {{ if eq .Values.global.storage "gcs"}}
-  key.json: {{.Values.gcs.key_json | b64enc}}
+  key.json: {{.Values.gcs.key_json}}
   builder-bucket: {{.Values.gcs.builder_bucket | b64enc }}
   registry-bucket: {{.Values.gcs.registry_bucket | b64enc }}
   database-bucket: {{.Values.gcs.database_bucket | b64enc }}{{ else if eq .Values.global.storage "azure"}}

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -75,7 +75,7 @@ azure:
 gcs:
   # key_json is expanded into a JSON file on the remote server. It must be
   # well-formatted JSON data.
-  key_json: ''
+  key_json: <base64-encoded JSON data>
   registry_bucket: "your-registry-bucket-name"
   database_bucket: "your-database-bucket-name"
   builder_bucket: "your-builder-bucket-name"
@@ -163,7 +163,7 @@ registry-token-refresher:
     registryid: ""
     hostname: ""
   gcr:
-    key_json: 'Paste JSON data here.'
+    key_json: <base64-encoded JSON data>
     hostname: ""
 
 router:

--- a/src/installing-workflow/configuring-object-storage.md
+++ b/src/installing-workflow/configuring-object-storage.md
@@ -41,7 +41,10 @@ Operators should configure object storage by editing the Helm values file before
 * Save your changes.
 
 !!! note
-	You do not need to base64 encode any of these values as Helm will handle encoding automatically.
+	All values will be automatically (base64) encoded _except_ the `key_json` values under `gcs`/`gcr`.  These must be base64-encoded.  This is to support cleanly passing said encoded text via `helm --set` cli functionality rather than attempting to pass the raw JSON data.  For example:
+
+		$ helm install workflow --namespace deis \
+			--set global.storage=gcs,gcs.key_json="$(cat /path/to/gcs_creds.json | base64 | tr -d '[:space:]')"
 
 You are now ready to run `helm install deis/workflow --namespace deis -f values.yaml` using your desired object storage.
 


### PR DESCRIPTION
To support passing json data via `--set` at `helm install` time.

Previously, the json data was expected to be un-encoded in the `values.yaml`, which worked fine at install time if `-f values.yaml` was used.  However, there is seemingly no easy way to pass json data via `helm install --set`...

TODO:
 - [x] add/modify docs as necessary