### PR TITLE
docs(releases): move workflow docs release after changelog PR

### DIFF
--- a/src/roadmap/releases.md
+++ b/src/roadmap/releases.md
@@ -159,9 +159,11 @@ Some Workflow components not in the Helm chart must also be tagged in sync with 
 Follow the [component release process](#how-to-release-a-component) above and ensure that
 these components are tagged:
 
-- [deis/workflow][]
 - [deis/workflow-cli][]
 - [deis/workflow-e2e][]
+
+The version number for [deis/workflow-cli][] should always match the overall Workflow version
+number.
 
 ### Step 3: Create Helm Chart
 
@@ -242,6 +244,10 @@ Make sure to add a header to the page to make it clear that this is for a Workfl
 ```
 ## Workflow v2.9.0 -> v2.9.1
 ```
+
+Once the PR has been reviewed and merged, do a [component release](#how-to-release-a-component) of
+[deis/workflow][] itself. The version number for [deis/workflow][] should always match the
+overall Workflow version number.
 
 ### Step 8: Close GitHub Milestones
 


### PR DESCRIPTION
This is how ~~(I think)~~ we've been doing releases of the `workflow` repo anyway, and it seems more logical to ensure that the v2.10.0 changelog is actually included in the v2.10.0 tag.

Also makes clear that we release workflow and workflow-cli in lockstep with the overall Workflow platform release, which we do.