### PR TITLE
docs(upgrading-workflow): add note about using single quotes around base64 encoded string

### DIFF
--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -37,8 +37,11 @@ $ helm upgrade deis/workflow
 ```
 $ B64_KEY_JSON="$(cat ~/path/to/key.json | base64 | tr -d '[:space:]')"
 $ helm upgrade <release_name> deis/workflow -f values.yaml --set gcs.key_json="${B64_KEY_JSON}",registry-token-refresher.gcr.key_json="${B64_KEY_JSON}"
-$ # alternatively, simply replace the appropriate values in values.yaml and do without the `--set` parameter
 ```
+
+Alternatively, simply replace the appropriate values in values.yaml and do without the `--set`
+parameter. Make sure to wrap it in single quotes as double quotes will give a parser error when
+upgrading.
 
 ### Step 2: Verify Upgrade
 


### PR DESCRIPTION
Helm doesn't like it when the base64-encoded string is wrapped in double quotes. Perhaps this is an
intentional thing due to the yaml parser, but it is good to call it out here.