### PR TITLE
docs(managing-workflow) Document k8s annotation for AWS ELB idle timeout

### DIFF
--- a/src/managing-workflow/configuring-load-balancers.md
+++ b/src/managing-workflow/configuring-load-balancers.md
@@ -6,7 +6,15 @@ Depending on what distribution of Kubernetes you use and where you host it, inst
 
 If a load balancer such as the one described above does exist (whether created automatically or manually) and if you intend on handling any long-running requests, the load balancer (or similar) may require some manual configuration to increase the idle connection timeout.  Typically, this is most applicable to AWS and Elastic Load Balancers, but may apply in other cases as well.  It does not apply to Google Container Engine, as the idle connection timeout cannot be configured there, but also works as-is.
 
-If, for instance, Deis Workflow were installed on kube-aws, this timeout should be increased to a recommended value of 1200 seconds.  This will ensure the load balancer does not hang up on the client during long-running operations like an application deployment.  Directions for this can be found [here](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html).
+If, for instance, Deis Workflow were installed on kube-aws, this timeout should be increased to a recommended value of 1200 seconds.  This will ensure the load balancer does not hang up on the client during long-running operations like an application deployment.
+
+If you are running Kubernetes v1.4 or later, you should configure the idle timeout using this service annotation:
+
+```
+$ kubectl --namespace=deis annotate service/deis-router service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout=1200
+```
+
+On older Kubernetes versions, you have to [configure the idle timeout manually](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html), but it will reset back to the default of 60 seconds whenever Kubernetes needs to reconfigure the load balancer, for example because a node in your cluster was added or removed. Remember to re-apply your manual changes if that happens.
 
 ## Configuring PROXY protocol
 


### PR DESCRIPTION
This updates the docs to describe how to persist the AWS ELB idle timeout by using the proper k8s service annotation instead of following the manual instructions, which get reset if k8s re-configures the ELB.

The annotation was added in kubernetes/kubernetes#30695 and merged targeting k8s v1.4 in August 2016. I have verified that it works as expected on k8s v1.4.6.