### PR TITLE
feat(configuring-load-balancers): use kubernetes idle timeout annotation

### DIFF
--- a/src/managing-workflow/configuring-load-balancers.md
+++ b/src/managing-workflow/configuring-load-balancers.md
@@ -6,7 +6,11 @@ Depending on what distribution of Kubernetes you use and where you host it, inst
 
 If a load balancer such as the one described above does exist (whether created automatically or manually) and if you intend on handling any long-running requests, the load balancer (or similar) may require some manual configuration to increase the idle connection timeout.  Typically, this is most applicable to AWS and Elastic Load Balancers, but may apply in other cases as well.  It does not apply to Google Container Engine, as the idle connection timeout cannot be configured there, but also works as-is.
 
-If, for instance, Deis Workflow were installed on kube-aws, this timeout should be increased to a recommended value of 1200 seconds.  This will ensure the load balancer does not hang up on the client during long-running operations like an application deployment.  Directions for this can be found [here](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-idle-timeout.html).
+If, for instance, Deis Workflow were installed on kube-aws, this timeout should be increased to a recommended value of 1200 seconds.  This will ensure the load balancer does not hang up on the client during long-running operations like an application deployment.  Tuning the idle timeout can be done with
+
+```
+$ kubectl --namespace=deis annotate service/deis-router service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout=1200
+```
 
 ## Configuring PROXY protocol
 


### PR DESCRIPTION
This annotation is undocumented, but was introduced in https://github.com/kubernetes/kubernetes/pull/30695. It has been available since k8s v1.4.