### PR TITLE
docs(installing): specify helm v2.1.3 as minimum everywhere

### DIFF
--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -11,12 +11,12 @@ Deis Workflow, follow the [quickstart guide](../quickstart/index.md) for assista
 
 ## Check Your Setup
 
-Check that the `helm` command is available and the version is 2.1.0 or newer.
+Check that the `helm` command is available and the version is v2.1.3 or newer.
 
 ```
 $ helm version
-Client: &version.Version{SemVer:"v2.1.0", GitCommit:"b7b648456ba15d3d190bb84b36a4bc9c41067cf3", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.1.0", GitCommit:"b7b648456ba15d3d190bb84b36a4bc9c41067cf3", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
 ```
 
 ## Choose Your Deployment Strategy

--- a/src/quickstart/provider/azure-acs/install-azure-acs.md
+++ b/src/quickstart/provider/azure-acs/install-azure-acs.md
@@ -2,15 +2,15 @@
 
 ## Check Your Setup
 
-First check that the `helm` command is available and the version is v2.0.0 or newer.
+First check that the `helm` command is available and the version is v2.1.3 or newer.
 
 ```
 $ helm version
-Client: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.0.0", GitCommit:"51bdad42756dfaf3234f53ef3d3cb6bcd94144c2", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
 ```
 
-Finally, intialize Helm:
+Finally, initialize Helm:
 ```
 helm init
 ```


### PR DESCRIPTION
The docs weren't consistent everywhere about requiring helm v2.1.3 or later.