### PR TITLE
Revert "feat(charts): introduce kube-registry-proxy"

### DIFF
--- a/charts/workflow/requirements.yaml
+++ b/charts/workflow/requirements.yaml
@@ -38,9 +38,9 @@ dependencies:
   - name: registry
     version: <registry-tag>
     repository: https://charts.deis.com/registry
-  - name: kube-registry-proxy
-    version: 0.1.0
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  - name: registry-proxy
+    version: <registry-proxy-tag>
+    repository: https://charts.deis.com/registry-proxy
   - name: registry-token-refresher
     version: <registry-token-refresher-tag>
     repository: https://charts.deis.com/registry-token-refresher

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -137,11 +137,6 @@ fluentd:
     # external syslog endpoint port
     port: ""
 
-kube-registry-proxy:
-  registry:
-    host: "$(DEIS_REGISTRY_SERVICE_HOST)"
-    port: "$(DEIS_REGISTRY_SERVICE_PORT)"
-
 monitor:
   grafana:
     user: "admin"


### PR DESCRIPTION
Reverts deis/workflow#734

We've seen issues where the `kube-registry-proxy` pod is not created after an upgrade to v2.12.0