### PR TITLE
docs(managing-app-configuration): update "kubernetes-probes" link

### DIFF
--- a/src/applications/managing-app-configuration.md
+++ b/src/applications/managing-app-configuration.md
@@ -227,7 +227,7 @@ environ  prod
 
 
 [attached resources]: http://12factor.net/backing-services
-[kubernetes-probes]: http://kubernetes.io/docs/user-guide/pod-states/#container-probes
+[kubernetes-probes]: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 [pods-to-nodes]: http://kubernetes.io/docs/user-guide/node-selection/
 [release]: ../reference-guide/terms.md#release
 [router]:  ../understanding-workflow/components.md#router


### PR DESCRIPTION
The previous link, https://kubernetes.io/docs/user-guide/pod-states/#container-probes, displays a message about Kubernetes docs being moved, and includes a link to the new location for the particular topic. (And no longer includes the content/documentation). 

I've updated the link to the new location, and proper heading anchor, in the Kubernetes Pod Lifecycle documentation: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes