### PR TITLE
docs(monitoring): Update docs to reflect monitor chart changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,5 @@ docker-build:
 
 docker-serve:
 	${DEV_ENV_CMD} ${IMAGE} $(MKDOCSSERVE)
+
+run: docker-build docker-serve

--- a/src/managing-workflow/tuning-component-settings.md
+++ b/src/managing-workflow/tuning-component-settings.md
@@ -130,10 +130,22 @@ NUMBER_OF_LINES   | How many lines to store in the ring buffer (default: 1000)
 
 ## Customizing the Monitor
 
-The monitor component uses [Telegraf](https://github.com/influxdata/telegraf) under the hood, and
-derives most of its configuration from it. Please see
-[telegraf configuration](https://github.com/influxdata/telegraf/blob/master/docs/CONFIGURATION.md)
-for more information on tuning the [Monitor][] component.
+### [Grafana](https://grafana.com/)
+We have exposed some of the more useful configuration values directly in the chart. This allows them to be set using either the `values.yaml` file or by using the `--set` flag with the Helm CLI. You can see these options below:
+
+Setting           | Default Value  | Description
+----------------- | -------------- |------------ |
+user   | "admin" | The first user created in the database (this user has admin privileges)
+password | "admin" | Password for the first user.
+allow_sign_up | "true" | Allows users to sign up for an account.
+
+For a list of other options you can set by using environment variables please see the [configuration file](https://github.com/deis/monitor/blob/master/grafana/rootfs/usr/share/grafana/grafana.ini.tpl) in Github.
+
+### [Telegraf](https://docs.influxdata.com/telegraf)
+For a list of configuration values that can be set by using environment variables please see the following [configuration file](https://github.com/deis/monitor/blob/master/telegraf/rootfs/config.toml.tpl).
+
+### [InfluxDB](https://docs.influxdata.com/influxdb)
+You can find a list of values that can be set using environment variables [here](https://github.com/deis/monitor/blob/master/influxdb/rootfs/home/influxdb/config.toml.tpl).
 
 ## Customizing the Registry
 


### PR DESCRIPTION
This updates several parts of the documentation related to monitoring it also adds a new make target called `run` which basically builds the docker image and calls `docker-serve`.

addresses part of https://github.com/deis/monitor/issues/171

Testing Steps:
* Clone PR
* `make run`
*  `Tuning Component Settings` page now has an updated Monitoring section
*  `Platform Monitoring`
  * Removed the section on creating the `Storage Class`
  * Added section on customizing (which takes you to the `Tuning Component Settings` page
  * Added a section on the 2.9.0 release of Monitoring and the changes to the InfluxDB chart

