### PR TITLE
docs(installing-workflow) to remove helm using the reset command

### DIFF
--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -33,7 +33,7 @@ $ helm init --service-account=tiller-deploy
 If `helm` is already installed in cluster without sufficient rights, the only way for now is to reinstall it:
 
 ```
-$ kubectl delete deployment tiller-deploy -n kube-system
+$ helm reset
 $ kubectl create sa tiller-deploy -n kube-system
 $ kubectl create clusterrolebinding helm --clusterrole=cluster-admin --serviceaccount=kube-system:tiller-deploy
 $ helm init --service-account=tiller-deploy


### PR DESCRIPTION
The former command would log a warning "Warning: Tiller is already installed in the cluster" and restart with the old configuration rather than using RBAC configuration. After replacing with helm reset the issue was resolved and new tiller was successfully installed.