### PR TITLE
docs(*): specify Helm v2.5.0 or later

### DIFF
--- a/src/_includes/install-workflow.md
+++ b/src/_includes/install-workflow.md
@@ -1,11 +1,11 @@
 ## Check Your Setup
 
-First check that the `helm` command is available and the version is v2.1.3 or newer.
+First check that the `helm` command is available and the version is v2.5.0 or newer.
 
 ```
 $ helm version
-Client: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
 ```
 
 Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.

--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -11,12 +11,12 @@ Deis Workflow, follow the [quickstart guide](../quickstart/index.md) for assista
 
 ## Check Your Setup
 
-Check that the `helm` command is available and the version is v2.1.3 or newer.
+Check that the `helm` command is available and the version is v2.5.0 or newer.
 
 ```
 $ helm version
-Client: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
 ```
 
 ### Check Your Authorization

--- a/src/quickstart/provider/azure-acs/install-azure-acs.md
+++ b/src/quickstart/provider/azure-acs/install-azure-acs.md
@@ -2,12 +2,12 @@
 
 ## Check Your Setup
 
-First check that the `helm` command is available and the version is v2.1.3 or newer.
+First check that the `helm` command is available and the version is v2.5.0 or newer.
 
 ```
 $ helm version
-Client: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
 ```
 
 Finally, initialize Helm:

--- a/src/quickstart/provider/minikube/install-minikube.md
+++ b/src/quickstart/provider/minikube/install-minikube.md
@@ -2,12 +2,12 @@
 
 ## Check Your Setup
 
-First check that the `helm` command is available and the version is v2.1.3 or newer.
+First check that the `helm` command is available and the version is v2.5.0 or newer.
 
 ```
 $ helm version
-Client: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.1.3", GitCommit:"5cbc48fb305ca4bf68c26eb8d2a7eb363227e973", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b8dab6c2d45be6", GitTreeState:"clean"}
 ```
 
 Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.


### PR DESCRIPTION
We don't test with old versions of Helm, so this simplifies the story for supporting Workflow.

Replaces #778.