### PR TITLE
docs(README.md): remove outdated license blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,6 @@ To serve documenation run: `make serve` or `make docker-serve`.
 
 Then view the documentation on [http://localhost:8000](http://localhost:8000) or `http://DOCKER_IP:8000`.
 
-## License
-
-Copyright 2013, 2014, 2015 Engine Yard, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>.
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
 [k8s-home]: http://kubernetes.io
 [install-k8s]: http://kubernetes.io/gettingstarted/
 [mkdocs]: http://www.mkdocs.org/


### PR DESCRIPTION
Microsoft relicensed as MIT several months ago.