### PR TITLE
WIP: declare "off_cluster_minio"

### DIFF
--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -9,6 +9,7 @@ global:
   # - gcs: Store persistent data in Google Cloud Storage
   # - minio: Store persistent data on in-cluster Minio server
   storage: minio
+  off_cluster_minio: true
 
   # Set the location of Workflow's PostgreSQL database
   #


### PR DESCRIPTION
for an External minio server using s3.accesskey and s3.secretkey,
will add s3.regionendpoint later

WIP: to resolve deis/workflow#481

More changes will go in deis/builder deis/controller deis/database
deis/registry, all of which have dependencies on s3/swift storage

In PoC I overrode DEIS_MINIO_SERVICE_HOST and DEIS_MINIO_SERVICE_PORT

I'd like to use that shortcut and it seems safe, but I'm open to doing it another way if it's cleaner.  I would decompose host and port from value in s3.regionendpoint, reorganizing values.yaml so the off-cluster minio configuration is very obvious.

I could not reliably use Deis Workflow on any of my (relatively not-top-of-the-line) portable machines via minikube or minishift without adding a remote storage server for minio, and adding some persistent disk.  Can we get the configuration for this mode worked out in 2.19 final release?